### PR TITLE
Turn off compliance checks in pipeline by default

### DIFF
--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -39,7 +39,7 @@ parameters:
 - name: EnableCompliance
   displayName: Run Compliance Tools
   type: boolean
-  default: true
+  default: false
 - name: EnableAPIScan
   displayName: Include APIScan with Compliance tools
   type: boolean


### PR DESCRIPTION
They double the pipeline runtime, adding ~20 minutes. We can always run them on-demand by checking the box when we queue the pipeline manually.