### PR TITLE
Add .NET implementation of brokered service container 

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -183,5 +183,8 @@ dotnet_diagnostic.DOC108.severity = warning
 dotnet_diagnostic.DOC200.severity = warning
 dotnet_diagnostic.DOC202.severity = warning
 
+# SA1601: Partial elements should be documented
+dotnet_diagnostic.SA1601.severity = silent
+
 [*.sln]
 indent_style = tab

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,6 +16,11 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" Version="$(CodefixTestingVersion)" />
     <PackageVersion Include="Microsoft.CodeCoverage" Version="17.5.0-release-20230105-01" />
+    <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.4.16" />
+    <PackageVersion Include="Microsoft.VisualStudio.RpcContracts" Version="17.4.9" />
+    <PackageVersion Include="Microsoft.VisualStudio.Utilities" Version="17.4.33216.74" />
+    <PackageVersion Include="Microsoft.VisualStudio.Utilities.Testing" Version="17.4.33216.74" />
+    <PackageVersion Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" Version="17.3.37" />
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
@@ -25,6 +30,7 @@
     <PackageVersion Include="StreamJsonRpc" Version="2.15.3-alpha" />
     <PackageVersion Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageVersion Include="TraceSource.ActivityTracing" Version="0.1.201-beta" />
     <PackageVersion Include="xunit" Version="2.4.2" />
     <PackageVersion Include="Xunit.Combinatorial" Version="1.5.25" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />

--- a/Microsoft.ServiceBroker.sln
+++ b/Microsoft.ServiceBroker.sln
@@ -48,6 +48,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ExternalTestAssembly", "tes
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ServiceBrokerTest", "test\ServiceBrokerTest\ServiceBrokerTest.csproj", "{C8E35A08-3C30-40E9-BE9B-8ABFBC0195C9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.ServiceHub.Framework.Testing", "src\Microsoft.ServiceHub.Framework.Testing\Microsoft.ServiceHub.Framework.Testing.csproj", "{6C97B1A9-2E9B-4ED4-932E-B83EE638B2E2}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Microsoft.ServiceHub.Framework.Testing.Tests", "test\Microsoft.ServiceHub.Framework.Testing.Tests\Microsoft.ServiceHub.Framework.Testing.Tests.csproj", "{42E43344-ED89-4760-A3EA-39598043492F}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -78,6 +82,14 @@ Global
 		{C8E35A08-3C30-40E9-BE9B-8ABFBC0195C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C8E35A08-3C30-40E9-BE9B-8ABFBC0195C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C8E35A08-3C30-40E9-BE9B-8ABFBC0195C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6C97B1A9-2E9B-4ED4-932E-B83EE638B2E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6C97B1A9-2E9B-4ED4-932E-B83EE638B2E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6C97B1A9-2E9B-4ED4-932E-B83EE638B2E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6C97B1A9-2E9B-4ED4-932E-B83EE638B2E2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{42E43344-ED89-4760-A3EA-39598043492F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{42E43344-ED89-4760-A3EA-39598043492F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{42E43344-ED89-4760-A3EA-39598043492F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{42E43344-ED89-4760-A3EA-39598043492F}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -91,6 +103,8 @@ Global
 		{3AD30282-F09F-449A-892A-27F9D6140BC0} = {EE7199AA-408F-4AD6-847D-190FCBFD4D9B}
 		{61F7D8BF-F0A7-4C62-A56E-D4E9B6F73518} = {EE7199AA-408F-4AD6-847D-190FCBFD4D9B}
 		{C8E35A08-3C30-40E9-BE9B-8ABFBC0195C9} = {EE7199AA-408F-4AD6-847D-190FCBFD4D9B}
+		{6C97B1A9-2E9B-4ED4-932E-B83EE638B2E2} = {4441D57D-78BF-441F-A530-6B1C5C321C1B}
+		{42E43344-ED89-4760-A3EA-39598043492F} = {EE7199AA-408F-4AD6-847D-190FCBFD4D9B}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {E3944F6A-384B-4B0F-B93F-3BD513DC57BD}

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -49,7 +49,7 @@ stages:
 
 - stage: Build
   variables:
-    MSBuildTreatWarningsAsErrors: true
+    MSBuildTreatWarningsAsErrors: false # re-enable when LCL files have been checked in, thereby eliminating the warnings about missing LCE files.
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
     BuildConfiguration: Release
     NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages

--- a/loc/lci/Microsoft.ServiceHub.Framework.Testing.dll.lci
+++ b/loc/lci/Microsoft.ServiceHub.Framework.Testing.dll.lci
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LCX SchemaVersion="6.0" Name="Microsoft.ServiceHub.Framework.Testing.dll" PsrId="211" FileType="1" SrcCul="en-US" xmlns="http://schemas.microsoft.com/locstudio/2006/6/lcx">
+  <OwnedComments>
+    <Cmt Name="LcxAdmin" />
+    <Cmt Name="Loc" />
+  </OwnedComments>
+</LCX>

--- a/src/Microsoft.ServiceHub.Framework.Testing/Microsoft.ServiceHub.Framework.Testing.csproj
+++ b/src/Microsoft.ServiceHub.Framework.Testing/Microsoft.ServiceHub.Framework.Testing.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <Description>A library that can assist in testing brokered service contracts.</Description>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Microsoft.ServiceHub.Framework\Microsoft.ServiceHub.Framework.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Microsoft.ServiceHub.Framework.Testing/MockBrokeredServiceContainer.cs
+++ b/src/Microsoft.ServiceHub.Framework.Testing/MockBrokeredServiceContainer.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using Microsoft.ServiceHub.Framework.Services;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+namespace Microsoft.ServiceHub.Framework.Testing;
+
+/// <summary>
+/// A mock implementation of <see cref="IBrokeredServiceContainer"/> suitable for unit tests.
+/// </summary>
+/// <remarks>
+/// This container does not require advance service registration.
+/// When a service is proffered, registration is automatically synthesized if necessary,
+/// exposing the service with <see cref="ServiceAudience.Local"/>.
+/// </remarks>
+public class MockBrokeredServiceContainer : GlobalBrokeredServiceContainer
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="MockBrokeredServiceContainer"/> class
+	/// with no <see cref="JoinableTaskFactory"/>.
+	/// A mock authorization service is installed that approves every request.
+	/// </summary>
+	/// <param name="traceSource">An optional <see cref="TraceSource"/> to log to.</param>
+	public MockBrokeredServiceContainer(TraceSource? traceSource = null)
+		: base(ImmutableDictionary<ServiceMoniker, ServiceRegistration>.Empty, isClientOfExclusiveServer: false, joinableTaskFactory: null, traceSource: traceSource ?? CreateNullTraceSource())
+	{
+		this.RegisterServices(new Dictionary<ServiceMoniker, ServiceRegistration>
+			{
+				{ FrameworkServices.Authorization.Moniker, new ServiceRegistration(ServiceAudience.Local, null, allowGuestClients: true) },
+			});
+		this.Proffer(FrameworkServices.Authorization, (mk, options, sb, ct) => new(new MockAuthorizationService()));
+	}
+
+	/// <inheritdoc />
+	public override IReadOnlyDictionary<string, string> LocalUserCredentials => ImmutableDictionary<string, string>.Empty;
+
+	/// <inheritdoc />
+	protected override IDisposable Proffer(IProffered proffered)
+	{
+		this.RegisterServicesIfNecessary(proffered);
+		return base.Proffer(proffered);
+	}
+
+	private static TraceSource CreateNullTraceSource()
+	{
+		var traceSource = new TraceSource("Mocks", SourceLevels.Off);
+		traceSource.Listeners.Clear(); // remove default listeners
+		return traceSource;
+	}
+
+	private void RegisterServicesIfNecessary(IProffered proffered)
+	{
+		var missingRegistrations = new Dictionary<ServiceMoniker, ServiceRegistration>();
+		foreach (ServiceMoniker moniker in proffered.Monikers)
+		{
+			if (!this.RegisteredServices.ContainsKey(moniker))
+			{
+				missingRegistrations.Add(moniker, new ServiceRegistration(ServiceAudience.Local, null, allowGuestClients: false));
+			}
+		}
+
+		this.RegisterServices(missingRegistrations);
+	}
+
+	private class MockAuthorizationService : IAuthorizationService
+	{
+		public event EventHandler? CredentialsChanged;
+
+		public event EventHandler? AuthorizationChanged;
+
+		public ValueTask<bool> CheckAuthorizationAsync(ProtectedOperation operation, CancellationToken cancellationToken = default) => new(true);
+
+		public ValueTask<IReadOnlyDictionary<string, string>> GetCredentialsAsync(CancellationToken cancellationToken = default) => new(ImmutableDictionary<string, string>.Empty);
+
+		protected virtual void OnCredentialsChanged(EventArgs args) => this.CredentialsChanged?.Invoke(this, args);
+
+		protected virtual void OnAuthorizationChanged(EventArgs args) => this.AuthorizationChanged?.Invoke(this, args);
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework.Testing/PublicAPI.Shipped.txt
+++ b/src/Microsoft.ServiceHub.Framework.Testing/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Microsoft.ServiceHub.Framework.Testing/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.ServiceHub.Framework.Testing/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+Microsoft.ServiceHub.Framework.Testing.MockBrokeredServiceContainer
+Microsoft.ServiceHub.Framework.Testing.MockBrokeredServiceContainer.MockBrokeredServiceContainer(System.Diagnostics.TraceSource? traceSource = null) -> void
+override Microsoft.ServiceHub.Framework.Testing.MockBrokeredServiceContainer.LocalUserCredentials.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+override Microsoft.ServiceHub.Framework.Testing.MockBrokeredServiceContainer.Proffer(Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.IProffered! proffered) -> System.IDisposable!

--- a/src/Microsoft.ServiceHub.Framework/Container/.editorconfig
+++ b/src/Microsoft.ServiceHub.Framework/Container/.editorconfig
@@ -1,0 +1,7 @@
+[*.cs]
+
+# SA1600: Elements should be documented
+dotnet_diagnostic.SA1600.severity = suggestion
+
+# SA1602: Enumeration items should be documented
+dotnet_diagnostic.SA1602.severity = suggestion

--- a/src/Microsoft.ServiceHub.Framework/Container/BrokeredServiceFactory.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/BrokeredServiceFactory.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.ServiceHub.Framework;
+using Microsoft.ServiceHub.Framework.Services;
+
+namespace Microsoft.VisualStudio.Shell.ServiceBroker;
+
+/// <summary>
+/// A delegate that creates new instances of a service to be exposed by an <see cref="IServiceBroker" />.
+/// </summary>
+/// <param name="moniker">The identifier for the service that is requested.</param>
+/// <param name="options">Additional options that alter how the service may be activated or provide additional data to the service constructor.</param>
+/// <param name="serviceBroker">The service broker that the service returned from this delegate should use to obtain any of its own dependencies.</param>
+/// <param name="cancellationToken">A token to indicate that the caller has lost interest in the result.</param>
+/// <returns>A unique instance of the service. If the value implements <see cref="IDisposable" />, the value will be disposed when the client disconnects.</returns>
+/// <seealso cref="IBrokeredServiceContainer.Proffer(ServiceRpcDescriptor, BrokeredServiceFactory)"/>
+public delegate ValueTask<object?> BrokeredServiceFactory(ServiceMoniker moniker, ServiceActivationOptions options, IServiceBroker serviceBroker, CancellationToken cancellationToken);
+
+/// <summary>
+/// A delegate that creates new instances of a service to be exposed by an <see cref="IServiceBroker" />.
+/// </summary>
+/// <param name="moniker">The identifier for the service that is requested.</param>
+/// <param name="options">Additional options that alter how the service may be activated or provide additional data to the service constructor.</param>
+/// <param name="serviceBroker">The service broker that the service returned from this delegate should use to obtain any of its own dependencies.</param>
+/// <param name="authorizationServiceClient">
+/// The authorization service for this brokered service to use.
+/// Must be disposed of by the service or the service factory, unless the service factory itself throws an exception.
+/// </param>
+/// <param name="cancellationToken">A token to indicate that the caller has lost interest in the result.</param>
+/// <returns>A unique instance of the service. If the value implements <see cref="IDisposable" />, the value will be disposed when the client disconnects.</returns>
+/// <seealso cref="IBrokeredServiceContainer.Proffer(ServiceRpcDescriptor, AuthorizingBrokeredServiceFactory)"/>
+public delegate ValueTask<object?> AuthorizingBrokeredServiceFactory(ServiceMoniker moniker, ServiceActivationOptions options, IServiceBroker serviceBroker, AuthorizationServiceClient authorizationServiceClient, CancellationToken cancellationToken);

--- a/src/Microsoft.ServiceHub.Framework/Container/ClientCredentialsPolicy.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/ClientCredentialsPolicy.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Shell.ServiceBroker;
+
+/// <summary>
+/// Policies that may apply to how to treat credentials.
+/// </summary>
+public enum ClientCredentialsPolicy
+{
+	/// <summary>
+	/// If the service request carries client credentials with it, use that instead of what this filter would apply.
+	/// </summary>
+	RequestOverridesDefault,
+
+	/// <summary>
+	/// Always replace the client credentials on a request with the set specified on this filter.
+	/// </summary>
+	FilterOverridesRequest,
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/ExportBrokeredServiceAttribute.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/ExportBrokeredServiceAttribute.cs
@@ -1,0 +1,129 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel.Composition;
+using Microsoft.ServiceHub.Framework;
+
+namespace Microsoft.VisualStudio.Shell.ServiceBroker;
+
+/// <summary>
+/// Exports a class as a brokered service.
+/// </summary>
+/// <remarks>
+/// <para>The class that this attribute is applied to must implement <see cref="IExportedBrokeredService"/>.</para>
+/// <para>Any other MEF attributes used by the class with this attribute applied should come from the System.ComponentModel.Composition namespace.</para>
+/// <para>This attribute may be applied multiple times if multiple versions of the brokered service are supported.</para>
+/// <para>
+/// Exported brokered services may import any other MEF export from the default scope, along with the following types (with no explicit contract name):
+/// <list type="bullet">
+/// <item><see cref="IServiceBroker"/></item>
+/// <item><see cref="ServiceMoniker"/></item>
+/// <item><see cref="ServiceActivationOptions"/></item>
+/// <item><see cref="ServiceHub.Framework.Services.AuthorizationServiceClient"/></item>
+/// </list>
+/// </para>
+/// <para>Brokered services may not import other brokered service. They must use <see cref="IServiceBroker"/> to acquire them.</para>
+/// </remarks>
+[AttributeUsage(AttributeTargets.Class, Inherited = false, AllowMultiple = true)]
+[MetadataAttribute]
+public class ExportBrokeredServiceAttribute : ExportAttribute
+{
+	private ServiceAudience audience = ServiceAudience.Process;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ExportBrokeredServiceAttribute"/> class.
+	/// </summary>
+	/// <param name="name">The name of the service (same as <see cref="ServiceMoniker.Name"/>.)</param>
+	/// <param name="version">The version of the proffered service (same as <see cref="ServiceMoniker.Version"/>). May be null.</param>
+	public ExportBrokeredServiceAttribute(string name, string? version)
+		: base(typeof(IExportedBrokeredService))
+	{
+		Requires.NotNullOrEmpty(name, nameof(name));
+		this.ServiceName = name;
+		this.ServiceVersion = version;
+	}
+
+	/// <summary>
+	/// Gets the <see cref="ServiceMoniker.Name"/> of the exported brokered service.
+	/// </summary>
+	public string ServiceName { get; }
+
+	/// <summary>
+	/// Gets the <see cref="ServiceMoniker.Version"/> of the exported brokered service.
+	/// </summary>
+	public string? ServiceVersion { get; }
+
+	/// <summary>
+	/// Gets or sets a value indicating which clients should be allowed to directly acquire this service.
+	/// Audiences may be bitwise-OR'd together to expand the set of clients that are allowed to acquire this service.
+	/// </summary>
+	/// <value>The default value is <see cref="ServiceAudience.Process"/>.</value>
+	/// <remarks>
+	/// This is an architectural control and not a security boundary, since untrusted parties may acquire a service
+	/// that you *do* allow to acquire this service, thus giving indirect access to this service to the untrusted client.
+	/// Use <see cref="ServiceHub.Framework.Services.IAuthorizationService"/> (usually via the caching
+	/// <see cref="ServiceHub.Framework.Services.AuthorizationServiceClient"/> wrapper) to perform security checks within
+	/// your publicly exposed methods to ensure the ultimate client is authorized to perform any operation.
+	/// </remarks>
+	/// <exception cref="ArgumentException">Thrown when an attempt is made to set this value to <see cref="ServiceAudience.None" />.</exception>
+	public ServiceAudience Audience
+	{
+		get => this.audience;
+		set
+		{
+			Requires.Range(value != ServiceAudience.None, nameof(value));
+			this.audience = value;
+		}
+	}
+
+	/// <summary>
+	/// Gets or sets a value indicating whether guest clients are allowed to transitively acquire this service.
+	/// By default (<see langword="false"/>), only owners are allowed to access a brokered service. To opt-in to allowing
+	/// guests to acquire the proffered service, set this to <see langword="true"/>. By setting this to <see langword="true"/> the service
+	/// now has sole responsibility in correctly using <see cref="Microsoft.ServiceHub.Framework.Services.IAuthorizationService"/>
+	/// to authorize sensitive operations.
+	/// </summary>
+	/// <remarks>
+	/// <para>Whereas <see cref="Audience"/> is an architectural control, this property defines the security boundary.</para>
+	///
+	/// <para> Transitive Access Example: Service A performs sensitive operations. It is proffered with <see cref="ServiceAudience.RemoteExclusiveClient"/>
+	/// so that it can only be *directly* acquired by owners. However, this is not sufficient to prevent unauthorized access.
+	/// If Service B is proffered with <see cref="ServiceAudience.AllClientsIncludingGuests"/>,
+	/// it can be *directly* acquired by guests. When Service B internally acquires an instance of Service A, this means that guests now have
+	/// *indirect* access to the sensitive operations in Service A. If Service A has not implemented authorization to guard sensitive operations,
+	/// this indirect access violates the security boundary.</para>
+	///
+	/// <para>In order to prevent untrusted parties transitively aquiring a service that should require authorization,
+	/// by default all brokered services are only accessible to owners. This is regardless of the value of <see cref="Audience"/>.
+	/// In the example above, if Service B has been aquired by a guest, the attempt to acquire Service A will fail.</para>
+	///
+	/// <para>When a service has implemented authorization to guard sensitive operations, it can opt-in to allowing
+	/// guest acquisition by setting this property to <see langword="true"/>.</para>
+	/// </remarks>
+	public bool AllowTransitiveGuestClients { get; set; }
+}
+
+/// <summary>
+/// Describes the metadata expected from the <see cref="ExportBrokeredServiceAttribute"/>.
+/// </summary>
+/// <devremarks>
+/// This should stay in sync with the metadata added by that attribute.
+/// Each metadata is declared as an array because that attribute has <see cref="AttributeUsageAttribute.AllowMultiple"/>
+/// set to <see langword="true"/>.
+/// </devremarks>
+#pragma warning disable SA1201 // Elements should appear in the correct order
+internal interface IBrokeredServicesExportMetadata
+#pragma warning restore SA1201 // Elements should appear in the correct order
+{
+	/// <inheritdoc cref="ExportBrokeredServiceAttribute.ServiceName"/>
+	string[] ServiceName { get; }
+
+	/// <inheritdoc cref="ExportBrokeredServiceAttribute.ServiceVersion"/>
+	string?[] ServiceVersion { get; }
+
+	/// <inheritdoc cref="ExportBrokeredServiceAttribute.Audience"/>
+	ServiceAudience[] Audience { get; }
+
+	/// <inheritdoc cref="ExportBrokeredServiceAttribute.AllowTransitiveGuestClients"/>
+	bool[] AllowTransitiveGuestClients { get; }
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.BrokeredServiceManifest.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.BrokeredServiceManifest.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.ServiceHub.Framework.Services;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+public partial class GlobalBrokeredServiceContainer
+{
+	/// <summary>
+	/// Exposes details about availability of locally proffered services for clients with a specific audience.
+	/// </summary>
+	private class BrokeredServiceManifest : IBrokeredServiceManifest
+	{
+		private readonly GlobalBrokeredServiceContainer container;
+		private readonly ServiceAudience serviceAudience;
+
+		internal BrokeredServiceManifest(GlobalBrokeredServiceContainer container, ServiceAudience serviceAudience)
+		{
+			this.container = container ?? throw new ArgumentNullException(nameof(container));
+			this.serviceAudience = serviceAudience;
+		}
+
+		/// <inheritdoc />
+		public ValueTask<IReadOnlyCollection<ServiceMoniker>> GetAvailableServicesAsync(CancellationToken cancellationToken)
+		{
+			ImmutableHashSet<ServiceMoniker>.Builder monikers = ImmutableHashSet.CreateBuilder<ServiceMoniker>();
+
+			// Enumerate every registered service
+			foreach (KeyValuePair<ServiceMoniker, ServiceRegistration> registration in this.container.registeredServices)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+
+				// Filter to just those services that are exposed to the service audience that received this service.
+				if (registration.Value.IsExposedTo(this.serviceAudience))
+				{
+					monikers.Add(registration.Key);
+				}
+			}
+
+			return new ValueTask<IReadOnlyCollection<ServiceMoniker>>(monikers.ToImmutable());
+		}
+
+		/// <inheritdoc />
+		public ValueTask<ImmutableSortedSet<Version?>> GetAvailableVersionsAsync(string serviceName, CancellationToken cancellationToken)
+		{
+			Requires.NotNull(serviceName, nameof(serviceName));
+
+			ImmutableSortedSet<Version?>.Builder versions = ImmutableSortedSet.CreateBuilder<Version?>();
+
+			// Enumerate every registered service looking for matching names.
+			// We can't simply look up based on the key in the dictionary because
+			// we want to find all the available versions.
+			foreach (KeyValuePair<ServiceMoniker, ServiceRegistration> registration in this.container.registeredServices)
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+				ServiceMoniker registeredMoniker = registration.Key;
+
+				if (serviceName == registeredMoniker.Name)
+				{
+					// Filter to just those services that are exposed to the service audience that received this service.
+					if (registration.Value.IsExposedTo(this.serviceAudience))
+					{
+						versions.Add(registeredMoniker.Version);
+					}
+				}
+			}
+
+			return new ValueTask<ImmutableSortedSet<Version?>>(versions.ToImmutable());
+		}
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.ChaosMonkey.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.ChaosMonkey.cs
@@ -1,0 +1,141 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.Serialization;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Threading;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+public partial class GlobalBrokeredServiceContainer
+{
+	private ChaosMonkey? chaosMonkeyConfiguration;
+
+	private enum ChaosBrokeredServiceAvailability
+	{
+		/// <summary>
+		/// No services will be artificially denied.
+		/// </summary>
+		AllowAll,
+
+		/// <summary>
+		/// All service requests will be denied.
+		/// </summary>
+		DenyAll,
+
+		/// <summary>
+		/// All requests will be denied if they would be fulfilled by a remote connection.
+		/// </summary>
+		DenyRemote,
+	}
+
+	/// <summary>
+	/// Loads and applies the content of a chaos monkey configuration.
+	/// </summary>
+	/// <param name="chaosMonkeyConfigurationPath">The path to a chaos monkey configuration file.</param>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>A task that represents the async operation.</returns>
+	[Obsolete("This API is reserved for Visual Studio internal use and may change or be removed in a future version.")]
+	protected async Task ApplyChaosMonkeyConfigurationAsync(string chaosMonkeyConfigurationPath, CancellationToken cancellationToken)
+	{
+		await TaskScheduler.Default;
+		using var configReader = new JsonTextReader(new StreamReader(new FileStream(chaosMonkeyConfigurationPath, FileMode.Open, FileAccess.Read, FileShare.Read, 4096, useAsync: true)));
+		JObject configurationJson = await JObject.LoadAsync(configReader, cancellationToken).ConfigureAwait(false);
+		var serializer = JsonSerializer.Create(new JsonSerializerSettings
+		{
+			ContractResolver = new CamelCasePropertyNamesContractResolver(),
+		});
+		this.chaosMonkeyConfiguration = configurationJson.ToObject<ChaosMonkey>(serializer) ?? throw new InvalidOperationException("Configuration deserialized to a null value.");
+
+		this.traceSource.TraceEvent(System.Diagnostics.TraceEventType.Information, 0, $"Chaos monkey configuration loaded from \"{Path.GetFullPath(chaosMonkeyConfigurationPath)}\".");
+
+		// Take a snapshot of the registeredServices in case it changes while iterating through the chaosMonkeyConfiguration services
+		System.Collections.Immutable.ImmutableDictionary<ServiceMoniker, ServiceRegistration> services = this.registeredServices;
+
+		// Warn of any configurations that don't match with known brokered services.
+		IEnumerable<ServiceMoniker>? invalidEntries = this.chaosMonkeyConfiguration.BrokeredServices?.Keys.Where(k => !services.ContainsKey(k));
+		if (invalidEntries?.Any() ?? false)
+		{
+			this.traceSource.TraceEvent(System.Diagnostics.TraceEventType.Warning, 0, $"Chaos monkey configuration found for non-registered brokered services: {string.Join(", ", invalidEntries)}");
+		}
+	}
+
+	private class ServiceMonikerKeyDictionaryConverter<T> : JsonConverter<Dictionary<ServiceMoniker, T>?>
+	{
+		public override Dictionary<ServiceMoniker, T>? ReadJson(JsonReader reader, Type objectType, Dictionary<ServiceMoniker, T>? existingValue, bool hasExistingValue, JsonSerializer serializer)
+		{
+			var map = new Dictionary<ServiceMoniker, T>();
+
+			while (true)
+			{
+				if (!reader.Read())
+				{
+					throw new EndOfStreamException();
+				}
+
+				if (reader.TokenType == JsonToken.EndObject)
+				{
+					break;
+				}
+
+				string? nameAndVersion = (string?)reader.Value;
+				Assumes.NotNull(nameAndVersion);
+				int slashIndex = nameAndVersion.IndexOf('/');
+				string name = slashIndex >= 0 ? nameAndVersion.Substring(0, slashIndex) : nameAndVersion;
+				Version? version = slashIndex >= 0 ? Version.Parse(nameAndVersion.Substring(slashIndex + 1)) : null;
+				ServiceMoniker moniker = version is null ? new ServiceMoniker(name) : new ServiceMoniker(name, version);
+
+				if (!reader.Read())
+				{
+					throw new EndOfStreamException();
+				}
+
+				T? value = serializer.Deserialize<T>(reader) ?? throw new InvalidOperationException("Value deserialized to null.");
+
+				map.Add(moniker, value);
+			}
+
+			return map;
+		}
+
+		public override void WriteJson(JsonWriter writer, Dictionary<ServiceMoniker, T>? value, JsonSerializer serializer)
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	/// <summary>
+	/// The data object to deserialize from a chaos monkey configuration file.
+	/// </summary>
+	/// <remarks>
+	/// See the ChaosMonkey.schema.json file for the full schema.
+	/// Sample JSON:
+	/// <code><![CDATA[
+	/// {
+	///   "brokeredServices": {
+	///     "monikerName/1.2": {
+	///       "availability": "localOnly"
+	///     }
+	///   }
+	/// }
+	/// ]]></code>
+	/// </remarks>
+	[DataContract]
+	private class ChaosMonkey
+	{
+		[DataMember]
+		[JsonConverter(typeof(ServiceMonikerKeyDictionaryConverter<ChaosBrokeredService>))]
+		internal Dictionary<ServiceMoniker, ChaosBrokeredService>? BrokeredServices { get; set; }
+	}
+
+	[DataContract]
+	private class ChaosBrokeredService
+	{
+		[DataMember]
+		internal ChaosBrokeredServiceAvailability Availability { get; set; }
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.IProffered.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.IProffered.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.ServiceHub.Framework;
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+public abstract partial class GlobalBrokeredServiceContainer
+{
+	/// <summary>
+	/// An object that tracks a proffered service or set of services.
+	/// </summary>
+	protected interface IProffered : IServiceBroker, IRemoteServiceBroker, IDisposable
+	{
+		/// <summary>
+		/// Gets an identifier for where the services are proffered from.
+		/// </summary>
+		ServiceSource Source { get; }
+
+		/// <summary>
+		/// Gets the set of monikers for the proffered services.
+		/// </summary>
+		ImmutableHashSet<ServiceMoniker> Monikers { get; }
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.MissingServiceDiagnosticsService.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.MissingServiceDiagnosticsService.cs
@@ -1,0 +1,56 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO.Pipelines;
+using Microsoft.ServiceHub.Framework;
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+public partial class GlobalBrokeredServiceContainer
+{
+	/// <summary>
+	/// A view-intrinsic brokered service that can analyze why that particular <see cref="View"/> is incapable of producing some requested service.
+	/// This service is accessible via <see cref="MissingServiceDiagnostics"/>.
+	/// </summary>
+	private class MissingServiceDiagnosticsService : IMissingServiceDiagnosticsService
+	{
+		private readonly View view;
+
+		internal MissingServiceDiagnosticsService(View view)
+		{
+			this.view = view;
+		}
+
+		/// <inheritdoc />
+		public async Task<MissingServiceAnalysis> AnalyzeMissingServiceAsync(ServiceMoniker missingServiceMoniker, CancellationToken cancellationToken)
+		{
+			(IProffered? profferingSource, MissingBrokeredServiceErrorCode errorCode) = await this.view.TryGetProfferingSourceAsync(missingServiceMoniker, cancellationToken).ConfigureAwait(false);
+
+			if (profferingSource is null)
+			{
+				return new MissingServiceAnalysis(errorCode, null);
+			}
+
+			// Try activating the service to see if the factory returns a non-null value.
+			try
+			{
+				IDuplexPipe? pipe = await profferingSource.GetPipeAsync(missingServiceMoniker, cancellationToken).ConfigureAwait(false);
+				if (pipe is null)
+				{
+					return new MissingServiceAnalysis(MissingBrokeredServiceErrorCode.ServiceFactoryReturnedNull, profferingSource.Source);
+				}
+
+				// Close the pipe, as we don't have a use for the service once we've acquired it.
+				await pipe.Input.CompleteAsync().ConfigureAwait(false);
+				await pipe.Output.CompleteAsync().ConfigureAwait(false);
+
+				// Everything checks out. Transient problem perhaps?
+				return new MissingServiceAnalysis(MissingBrokeredServiceErrorCode.NoExplanation, profferingSource.Source);
+			}
+			catch (ServiceCompositionException)
+			{
+				// We consider an error the same as a missing service and wait for a relevant AvailabilityChanged event to try again.
+				return new MissingServiceAnalysis(MissingBrokeredServiceErrorCode.ServiceFactoryFault, profferingSource.Source);
+			}
+		}
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.ProfferedRemoteServiceBroker.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.ProfferedRemoteServiceBroker.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO.Pipelines;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Threading;
+using Nerdbank.Streams;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+public partial class GlobalBrokeredServiceContainer
+{
+	/// <summary>
+	/// Services a brokered service that is proffered via a <see cref="IRemoteServiceBroker"/>.
+	/// </summary>
+	[DebuggerDisplay("{" + nameof(DebuggerDisplay) + "}")]
+	protected class ProfferedRemoteServiceBroker : IProffered
+	{
+		private readonly GlobalBrokeredServiceContainer container;
+		private readonly AsyncLazy<IServiceBroker> serviceBroker;
+
+		internal ProfferedRemoteServiceBroker(GlobalBrokeredServiceContainer container, IRemoteServiceBroker remoteServiceBroker, MultiplexingStream? multiplexingStream, ServiceSource source, IReadOnlyCollection<ServiceMoniker> serviceMonikers)
+		{
+			this.container = container ?? throw new ArgumentNullException(nameof(container));
+			this.RemoteServiceBroker = remoteServiceBroker ?? throw new ArgumentNullException(nameof(remoteServiceBroker));
+			this.Source = source;
+			this.Monikers = serviceMonikers?.ToImmutableHashSet() ?? throw new ArgumentNullException(nameof(serviceMonikers));
+
+			this.RemoteServiceBroker.AvailabilityChanged += this.OnAvailabilityChanged;
+
+			this.serviceBroker = new AsyncLazy<IServiceBroker>(
+				async () =>
+				{
+					return multiplexingStream is not null
+						? await Microsoft.ServiceHub.Framework.RemoteServiceBroker.ConnectToMultiplexingServerAsync(remoteServiceBroker, multiplexingStream).ConfigureAwait(false)
+						: await Microsoft.ServiceHub.Framework.RemoteServiceBroker.ConnectToServerAsync(remoteServiceBroker).ConfigureAwait(false);
+				},
+				this.container.joinableTaskFactory);
+		}
+
+		/// <inheritdoc/>
+		public event EventHandler<BrokeredServicesChangedEventArgs>? AvailabilityChanged
+		{
+			add => this.RemoteServiceBroker.AvailabilityChanged += value;
+			remove => this.RemoteServiceBroker.AvailabilityChanged -= value;
+		}
+
+		/// <inheritdoc/>
+		public ImmutableHashSet<ServiceMoniker> Monikers { get; }
+
+		/// <inheritdoc/>
+		public ServiceSource Source { get; }
+
+		private IRemoteServiceBroker RemoteServiceBroker { get; }
+
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+		private string DebuggerDisplay => $"{this.RemoteServiceBroker} with {this.Monikers.Count} services including {this.Monikers.FirstOrDefault()}.";
+
+		/// <inheritdoc/>
+		public void Dispose()
+		{
+			this.RemoteServiceBroker.AvailabilityChanged -= this.OnAvailabilityChanged;
+			this.container.RemoveRegistrations(this);
+		}
+
+		/// <inheritdoc/>
+		public async ValueTask<IDuplexPipe?> GetPipeAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions options, CancellationToken cancellationToken)
+		{
+			IServiceBroker broker = await this.serviceBroker.GetValueAsync().ConfigureAwait(false);
+			return await broker.GetPipeAsync(serviceMoniker, options, cancellationToken).ConfigureAwait(false);
+		}
+
+		/// <inheritdoc/>
+		public async ValueTask<T?> GetProxyAsync<T>(ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options, CancellationToken cancellationToken)
+			where T : class
+		{
+			IServiceBroker broker = await this.serviceBroker.GetValueAsync().ConfigureAwait(false);
+			GC.KeepAlive(typeof(ValueTask<T>)); // workaround CLR bug https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1358442
+			return await broker.GetProxyAsync<T>(serviceDescriptor, options, cancellationToken).ConfigureAwait(false);
+		}
+
+		/// <inheritdoc />
+		Task IRemoteServiceBroker.HandshakeAsync(ServiceBrokerClientMetadata clientMetadata, CancellationToken cancellationToken)
+		{
+			return this.RemoteServiceBroker.HandshakeAsync(clientMetadata, cancellationToken);
+		}
+
+		/// <inheritdoc />
+		Task<RemoteServiceConnectionInfo> IRemoteServiceBroker.RequestServiceChannelAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions serviceActivationOptions, CancellationToken cancellationToken)
+		{
+			return this.RemoteServiceBroker.RequestServiceChannelAsync(serviceMoniker, serviceActivationOptions, cancellationToken);
+		}
+
+		/// <inheritdoc />
+		Task IRemoteServiceBroker.CancelServiceRequestAsync(Guid serviceRequestId)
+		{
+			return this.RemoteServiceBroker.CancelServiceRequestAsync(serviceRequestId);
+		}
+
+		private void OnAvailabilityChanged(object? sender, BrokeredServicesChangedEventArgs args)
+		{
+			this.container.OnAvailabilityChanged(null, this, args.ImpactedServices);
+		}
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.ProfferedServiceBroker.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.ProfferedServiceBroker.cs
@@ -1,0 +1,94 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO.Pipelines;
+using Microsoft.ServiceHub.Framework;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+public partial class GlobalBrokeredServiceContainer
+{
+	/// <summary>
+	/// Services brokered services that are proffered via an in-proc <see cref="IServiceBroker"/>.
+	/// </summary>
+	[DebuggerDisplay("{" + nameof(DebuggerDisplay) + "}")]
+	protected class ProfferedServiceBroker : IProffered
+	{
+		private readonly GlobalBrokeredServiceContainer container;
+		private readonly IRemoteServiceBroker remoteServiceBrokerWrapper;
+
+		internal ProfferedServiceBroker(GlobalBrokeredServiceContainer container, IServiceBroker serviceBroker, ServiceSource source, IReadOnlyCollection<ServiceMoniker> serviceMonikers)
+		{
+			this.container = container ?? throw new ArgumentNullException(nameof(container));
+			this.ServiceBroker = serviceBroker ?? throw new ArgumentNullException(nameof(serviceBroker));
+			this.Source = source;
+			this.Monikers = serviceMonikers?.ToImmutableHashSet() ?? throw new ArgumentNullException(nameof(serviceMonikers));
+			serviceBroker.AvailabilityChanged += this.OnAvailabilityChanged;
+			this.remoteServiceBrokerWrapper = new RemoteServiceBrokerWrapper(this);
+		}
+
+		/// <inheritdoc/>
+		public event EventHandler<BrokeredServicesChangedEventArgs>? AvailabilityChanged
+		{
+			add => this.ServiceBroker.AvailabilityChanged += value;
+			remove => this.ServiceBroker.AvailabilityChanged -= value;
+		}
+
+		/// <inheritdoc/>
+		public ImmutableHashSet<ServiceMoniker> Monikers { get; }
+
+		/// <inheritdoc/>
+		public ServiceSource Source { get; }
+
+		private IServiceBroker ServiceBroker { get; }
+
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+		private string DebuggerDisplay => $"{this.ServiceBroker} with {this.Monikers.Count} services including {this.Monikers.FirstOrDefault()}.";
+
+		/// <inheritdoc/>
+		public void Dispose()
+		{
+			this.ServiceBroker.AvailabilityChanged -= this.OnAvailabilityChanged;
+			this.container.RemoveRegistrations(this);
+		}
+
+		/// <inheritdoc/>
+		public ValueTask<IDuplexPipe?> GetPipeAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions options, CancellationToken cancellationToken)
+		{
+			return this.ServiceBroker.GetPipeAsync(serviceMoniker, options, cancellationToken);
+		}
+
+		/// <inheritdoc/>
+		public ValueTask<T?> GetProxyAsync<T>(ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options, CancellationToken cancellationToken)
+			where T : class
+		{
+			return this.ServiceBroker.GetProxyAsync<T>(serviceDescriptor, options, cancellationToken);
+		}
+
+		/// <inheritdoc />
+		Task IRemoteServiceBroker.HandshakeAsync(ServiceBrokerClientMetadata clientMetadata, CancellationToken cancellationToken)
+		{
+			return this.remoteServiceBrokerWrapper.HandshakeAsync(clientMetadata, cancellationToken);
+		}
+
+		/// <inheritdoc />
+		Task<RemoteServiceConnectionInfo> IRemoteServiceBroker.RequestServiceChannelAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions serviceActivationOptions, CancellationToken cancellationToken)
+		{
+			return this.remoteServiceBrokerWrapper.RequestServiceChannelAsync(serviceMoniker, serviceActivationOptions, cancellationToken);
+		}
+
+		/// <inheritdoc />
+		Task IRemoteServiceBroker.CancelServiceRequestAsync(Guid serviceRequestId)
+		{
+			return this.remoteServiceBrokerWrapper.CancelServiceRequestAsync(serviceRequestId);
+		}
+
+		private void OnAvailabilityChanged(object? sender, BrokeredServicesChangedEventArgs args)
+		{
+			this.container.OnAvailabilityChanged(null, this, args.OtherServicesImpacted ? this.Monikers : args.ImpactedServices);
+		}
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.ProfferedServiceFactory.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.ProfferedServiceFactory.cs
@@ -1,0 +1,250 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO.Pipelines;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.ServiceHub.Framework.Services;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+using Nerdbank.Streams;
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+public abstract partial class GlobalBrokeredServiceContainer
+{
+	/// <summary>
+	/// Services a brokered service that is proffered via an in-proc factory.
+	/// </summary>
+	[DebuggerDisplay("{" + nameof(DebuggerDisplay) + "}")]
+	protected class ProfferedServiceFactory : IProffered
+	{
+		private static readonly ProtectedOperation ClientIsOwnerProtectedOperation = WellKnownProtectedOperations.CreateClientIsOwner();
+
+		internal ProfferedServiceFactory(GlobalBrokeredServiceContainer container, ServiceRpcDescriptor descriptor, BrokeredServiceFactory factory)
+		{
+			this.Container = container ?? throw new ArgumentNullException(nameof(container));
+			this.Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+			this.Factory = factory ?? throw new ArgumentNullException(nameof(factory));
+			this.Monikers = ImmutableHashSet.Create(this.Descriptor.Moniker);
+			this.RemoteServiceBrokerWrapper = new RemoteServiceBrokerWrapper(this);
+		}
+
+		internal ProfferedServiceFactory(GlobalBrokeredServiceContainer container, ServiceRpcDescriptor descriptor, AuthorizingBrokeredServiceFactory factory)
+		{
+			this.Container = container ?? throw new ArgumentNullException(nameof(container));
+			this.Descriptor = descriptor ?? throw new ArgumentNullException(nameof(descriptor));
+			this.AuthorizingFactory = factory ?? throw new ArgumentNullException(nameof(factory));
+			this.Monikers = ImmutableHashSet.Create(this.Descriptor.Moniker);
+			this.RemoteServiceBrokerWrapper = new RemoteServiceBrokerWrapper(this);
+		}
+
+		/// <summary>
+		/// We never raise this event, so just drop the handlers on the floor.
+		/// </summary>
+		public event EventHandler<BrokeredServicesChangedEventArgs>? AvailabilityChanged
+		{
+			add { }
+			remove { }
+		}
+
+		/// <inheritdoc/>
+		public ServiceSource Source => ServiceSource.SameProcess; // individual service factories are *always* local to this process.
+
+		/// <inheritdoc/>
+		public ImmutableHashSet<ServiceMoniker> Monikers { get; }
+
+		/// <summary>
+		/// Gets the descriptor that was provided with the factory.
+		/// </summary>
+		protected internal ServiceRpcDescriptor Descriptor { get; }
+
+		/// <summary>
+		/// Gets the factory, if one was provided that did not take an <see cref="AuthorizationServiceClient"/>.
+		/// </summary>
+		protected BrokeredServiceFactory? Factory { get; }
+
+		/// <summary>
+		/// Gets the factory, if one was provided that takes an <see cref="AuthorizationServiceClient"/>.
+		/// </summary>
+		protected AuthorizingBrokeredServiceFactory? AuthorizingFactory { get; }
+
+		/// <summary>
+		/// Gets the container.
+		/// </summary>
+		protected GlobalBrokeredServiceContainer Container { get; }
+
+		private protected RemoteServiceBrokerWrapper RemoteServiceBrokerWrapper { get; }
+
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+		private string DebuggerDisplay => $"{this.Descriptor.Moniker}";
+
+		/// <inheritdoc/>
+		public void Dispose()
+		{
+			this.Container.RemoveRegistrations(this);
+		}
+
+		/// <inheritdoc/>
+		public virtual async ValueTask<IDuplexPipe?> GetPipeAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions options, CancellationToken cancellationToken)
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+
+			(IDuplexPipe, IDuplexPipe) pipePair = FullDuplexStream.CreatePipePair();
+
+			ServiceRpcDescriptor descriptor = this.Descriptor is ServiceJsonRpcDescriptor serviceJsonRpcDescriptor
+				 ? serviceJsonRpcDescriptor.MultiplexingStreamOptions is object ? this.Descriptor :
+
+					// We encourage users to migrate to descriptors configured with ServiceJsonRpcDescriptor.WithMultiplexingStream(MultiplexingStream.Options).
+#pragma warning disable CS0618 // Type or member is obsolete, only for backward compatibility.
+					this.Descriptor.WithMultiplexingStream(options.MultiplexingStream)
+#pragma warning restore CS0618 // Type or member is obsolete
+				 : this.Descriptor;
+
+			IServiceBroker serviceBroker = this.Container.GetSecureServiceBroker(options);
+			descriptor = descriptor
+				.WithTraceSource(await this.Container.GetTraceSourceForConnectionAsync(serviceBroker, serviceMoniker, options, clientRole: false, cancellationToken).ConfigureAwait(false));
+
+			using (options.ApplyCultureToCurrentContext())
+			{
+				ServiceRpcDescriptor.RpcConnection connection = descriptor.ConstructRpcConnection(pipePair.Item1);
+
+				// If the service needs to be able to call back to the client, arrange for it.
+				// If the client is remote, we need to create an RPC proxy back to the client.
+				// If the client is local, it should provide itself as the RPC target. So we only provide one if the client hasn't already done so.
+				// FWIW: it would be pretty odd if (ClientRpcTarget != null) since they're asking for a pipe so presumably they are remote.
+				if (descriptor.ClientInterface != null && options.ClientRpcTarget == null)
+				{
+					options.ClientRpcTarget = connection.ConstructRpcClient(descriptor.ClientInterface);
+				}
+
+				object? server = await this.InvokeFactoryAsync(serviceBroker, descriptor.Moniker, options, cancellationToken).ConfigureAwait(false);
+				try
+				{
+					if (server is object)
+					{
+						connection.AddLocalRpcTarget(server);
+						connection.StartListening();
+						return pipePair.Item2;
+					}
+					else
+					{
+						connection.Dispose();
+						return null;
+					}
+				}
+				catch
+				{
+					(server as IDisposable)?.Dispose();
+					throw;
+				}
+			}
+		}
+
+		/// <inheritdoc/>
+		public virtual async ValueTask<T?> GetProxyAsync<T>(ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options, CancellationToken cancellationToken)
+			where T : class
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+
+			IServiceBroker serviceBroker = this.Container.GetSecureServiceBroker(options);
+			serviceDescriptor = serviceDescriptor
+				.WithTraceSource(await this.Container.GetTraceSourceForConnectionAsync(serviceBroker, serviceDescriptor.Moniker, options, clientRole: false, cancellationToken).ConfigureAwait(false));
+
+			object? liveObject = await this.InvokeFactoryAsync(serviceBroker, serviceDescriptor.Moniker, options, cancellationToken).ConfigureAwait(false);
+			try
+			{
+				return serviceDescriptor.ConstructLocalProxy((T?)liveObject);
+			}
+			catch
+			{
+				(liveObject as IDisposable)?.Dispose();
+				throw;
+			}
+		}
+
+		/// <inheritdoc />
+		Task IRemoteServiceBroker.HandshakeAsync(ServiceBrokerClientMetadata clientMetadata, CancellationToken cancellationToken)
+		{
+			return this.RemoteServiceBrokerWrapper.HandshakeAsync(clientMetadata, cancellationToken);
+		}
+
+		/// <inheritdoc />
+		Task<RemoteServiceConnectionInfo> IRemoteServiceBroker.RequestServiceChannelAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions serviceActivationOptions, CancellationToken cancellationToken)
+		{
+			return this.RemoteServiceBrokerWrapper.RequestServiceChannelAsync(serviceMoniker, serviceActivationOptions, cancellationToken);
+		}
+
+		/// <inheritdoc />
+		Task IRemoteServiceBroker.CancelServiceRequestAsync(Guid serviceRequestId)
+		{
+			return this.RemoteServiceBrokerWrapper.CancelServiceRequestAsync(serviceRequestId);
+		}
+
+		private async ValueTask<object?> InvokeFactoryAsync(IServiceBroker serviceBroker, ServiceMoniker moniker, ServiceActivationOptions options, CancellationToken cancellationToken)
+		{
+			bool allowsGuests = false;
+			if (this.Container.TryLookupServiceRegistration(moniker, out ServiceRegistration? serviceRegistration, out _))
+			{
+				allowsGuests = serviceRegistration.AllowGuestClients;
+			}
+
+			IAuthorizationService? authorizationService = null;
+
+			try
+			{
+				if (!allowsGuests)
+				{
+					// To prevent infinite recursion, only try to acquire the Authorization service if allowsGuests is false
+					authorizationService = await serviceBroker.GetProxyAsync<IAuthorizationService>(FrameworkServices.Authorization, cancellationToken).ConfigureAwait(false);
+					Assumes.Present(authorizationService);
+					if (!await authorizationService.CheckAuthorizationAsync(ClientIsOwnerProtectedOperation, cancellationToken).ConfigureAwait(false))
+					{
+						return null;
+					}
+				}
+
+				if (this.Factory != null)
+				{
+					return await this.Factory(moniker, options, serviceBroker, cancellationToken).ConfigureAwait(false);
+				}
+				else if (this.AuthorizingFactory != null)
+				{
+					AuthorizationServiceClient? authClient = null;
+					try
+					{
+						if (authorizationService is null)
+						{
+							authorizationService = await serviceBroker.GetProxyAsync<IAuthorizationService>(FrameworkServices.Authorization, cancellationToken).ConfigureAwait(false);
+							Assumes.Present(authorizationService);
+						}
+
+						authClient = new AuthorizationServiceClient(authorizationService);
+						authorizationService = null; // we no longer own this instance, so don't dispose it later.
+
+						object? result = await this.AuthorizingFactory(moniker, options, serviceBroker, authClient, cancellationToken).ConfigureAwait(false);
+						if (result is null)
+						{
+							authClient.Dispose();
+						}
+
+						return result;
+					}
+					catch
+					{
+						authClient?.Dispose();
+						throw;
+					}
+				}
+				else
+				{
+					throw Assumes.NotReachable();
+				}
+			}
+			finally
+			{
+				(authorizationService as IDisposable)?.Dispose();
+			}
+		}
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.ProfferedViewIntrinsicService.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.ProfferedViewIntrinsicService.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO.Pipelines;
+using Microsoft.ServiceHub.Framework;
+using Nerdbank.Streams;
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+public abstract partial class GlobalBrokeredServiceContainer
+{
+	/// <summary>
+	/// This delegate is modeled after <see cref="ProfferedServiceFactory"/> but adds the <see cref="View"/> parameter.
+	/// </summary>
+	private delegate ValueTask<object?> ViewIntrinsicBrokeredServiceFactory(View view, ServiceMoniker moniker, ServiceActivationOptions options, IServiceBroker serviceBroker, CancellationToken cancellationToken);
+
+	private class ProfferedViewIntrinsicService : ProfferedServiceFactory
+	{
+		private readonly ViewIntrinsicBrokeredServiceFactory factory;
+
+		internal ProfferedViewIntrinsicService(GlobalBrokeredServiceContainer container, ServiceRpcDescriptor descriptor, ViewIntrinsicBrokeredServiceFactory factory)
+			: base(container, descriptor, (mk, options, sb, ct) => throw new NotSupportedException())
+		{
+			this.factory = factory ?? throw new ArgumentNullException(nameof(factory));
+		}
+
+		public override ValueTask<IDuplexPipe?> GetPipeAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions options = default, CancellationToken cancellationToken = default)
+		{
+			throw new NotSupportedException();
+		}
+
+		public override ValueTask<T?> GetProxyAsync<T>(ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options = default, CancellationToken cancellationToken = default)
+			where T : class
+		{
+			throw new NotSupportedException();
+		}
+
+		public async ValueTask<IDuplexPipe?> GetPipeAsync(View view, ServiceMoniker serviceMoniker, ServiceActivationOptions options = default, CancellationToken cancellationToken = default)
+		{
+			(IDuplexPipe, IDuplexPipe) pipePair = FullDuplexStream.CreatePipePair();
+
+			ServiceRpcDescriptor descriptor = this.Descriptor is ServiceJsonRpcDescriptor serviceJsonRpcDescriptor
+				 ? serviceJsonRpcDescriptor.MultiplexingStreamOptions is object ? this.Descriptor :
+
+					// We encourage users to migrate to descriptors configured with ServiceJsonRpcDescriptor.WithMultiplexingStream(MultiplexingStream.Options).
+#pragma warning disable CS0618 // Type or member is obsolete, only for backward compatibility.
+					this.Descriptor.WithMultiplexingStream(options.MultiplexingStream)
+#pragma warning restore CS0618 // Type or member is obsolete
+				 : this.Descriptor;
+
+			IServiceBroker serviceBroker = this.Container.GetSecureServiceBroker(options);
+			descriptor = descriptor
+				.WithTraceSource(await this.Container.GetTraceSourceForConnectionAsync(serviceBroker, serviceMoniker, options, clientRole: false, cancellationToken).ConfigureAwait(false));
+
+			using (options.ApplyCultureToCurrentContext())
+			{
+				ServiceRpcDescriptor.RpcConnection connection = descriptor.ConstructRpcConnection(pipePair.Item1);
+
+				// If the service needs to be able to call back to the client, arrange for it.
+				// If the client is remote, we need to create an RPC proxy back to the client.
+				// If the client is local, it should provide itself as the RPC target. So we only provide one if the client hasn't already done so.
+				// FWIW: it would be pretty odd if (ClientRpcTarget != null) since they're asking for a pipe so presumably they are remote.
+				if (descriptor.ClientInterface != null && options.ClientRpcTarget == null)
+				{
+					options.ClientRpcTarget = connection.ConstructRpcClient(descriptor.ClientInterface);
+				}
+
+				object? server = await this.factory(view, descriptor.Moniker, options, serviceBroker, cancellationToken).ConfigureAwait(false);
+				if (server != null)
+				{
+					connection.AddLocalRpcTarget(server);
+					connection.StartListening();
+					return pipePair.Item2;
+				}
+				else
+				{
+					connection.Dispose();
+				}
+
+				return null;
+			}
+		}
+
+		public async ValueTask<T?> GetProxyAsync<T>(View view, ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options = default, CancellationToken cancellationToken = default)
+			where T : class
+		{
+			IServiceBroker serviceBroker = this.Container.GetSecureServiceBroker(options);
+			serviceDescriptor = serviceDescriptor
+				.WithTraceSource(await this.Container.GetTraceSourceForConnectionAsync(serviceBroker, serviceDescriptor.Moniker, options, clientRole: false, cancellationToken).ConfigureAwait(false));
+			var liveObject = (T?)await this.factory(view, serviceDescriptor.Moniker, options, serviceBroker, cancellationToken).ConfigureAwait(false);
+			return serviceDescriptor.ConstructLocalProxy(liveObject);
+		}
+
+		public Task<RemoteServiceConnectionInfo> RequestServiceChannelAsync(View view, ServiceMoniker serviceMoniker, ServiceActivationOptions serviceActivationOptions, CancellationToken cancellationToken = default)
+		{
+			return this.RemoteServiceBrokerWrapper.RequestServiceChannelAsync(
+				() => this.GetPipeAsync(view, serviceMoniker, serviceActivationOptions, cancellationToken),
+				serviceMoniker,
+				serviceActivationOptions,
+				cancellationToken);
+		}
+
+		private Task<RemoteServiceConnectionInfo> RequestServiceChannelAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions serviceActivationOptions, CancellationToken cancellationToken)
+		{
+			throw new NotSupportedException();
+		}
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.RequestResult.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.RequestResult.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+public abstract partial class GlobalBrokeredServiceContainer
+{
+	/// <summary>
+	/// Enumerates the possible handling result of a brokered service request.
+	/// </summary>
+	/// <devremarks>
+	/// Although these enum values are each set to unique bits, it isn't a flags enum.
+	/// They are unique bits to allow convenient packing as we internally track which result types we've already posted telemetry events for.
+	/// </devremarks>
+	protected enum RequestResult
+	{
+		/// <summary>
+		/// The requested brokered service was activated, fulfilling the request.
+		/// </summary>
+		Fulfilled = 0x1,
+
+		/// <summary>
+		/// The request was declined for reasons other than the service not being found.
+		/// This could be because authorization was denied, or the service factory returned <see langword="null" /> or threw an exception.
+		/// </summary>
+		Declined = 0x2,
+
+		/// <summary>
+		/// The request was declined because the service was not registered.
+		/// </summary>
+		DeclinedNotFound = 0x4,
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.RequestType.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.RequestType.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+public abstract partial class GlobalBrokeredServiceContainer
+{
+	/// <summary>
+	/// Enumerates the types of brokered service requests that can be made.
+	/// </summary>
+	protected enum RequestType
+	{
+		/// <summary>
+		/// The request was for a proxy to a brokered service.
+		/// </summary>
+		Proxy,
+
+		/// <summary>
+		/// The request was for a pipe to a brokered service.
+		/// </summary>
+		Pipe,
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.TraceEvents.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.TraceEvents.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+public abstract partial class GlobalBrokeredServiceContainer
+{
+	/// <summary>
+	/// The IDs used for events logged via <see cref="TraceSource.TraceEvent(TraceEventType, int)"/>.
+	/// </summary>
+	protected enum TraceEvents
+	{
+		/// <summary>
+		/// Indicates brokered services have been registered.
+		/// </summary>
+		Registered,
+
+		/// <summary>
+		/// Indicates brokered services have been proffered.
+		/// </summary>
+		Proffered,
+
+		/// <summary>
+		/// Indicates a brokered service has been requested.
+		/// </summary>
+		Request,
+
+		/// <summary>
+		/// Indicates that the container is activating a host of a brokered service so that it may proffer a registered brokered service.
+		/// </summary>
+		LoadPackage,
+
+		/// <summary>
+		/// Indicates that a handler of some brokered service event threw an unhandled exception.
+		/// </summary>
+		EventHandlerFaulted,
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.View.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.View.cs
@@ -1,0 +1,522 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO.Pipelines;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+public abstract partial class GlobalBrokeredServiceContainer
+{
+	/// <summary>
+	/// A filtered view on the services proffered to a <see cref="GlobalBrokeredServiceContainer"/>, exposed as an <see cref="IServiceBroker"/>.
+	/// </summary>
+	[DebuggerDisplay("{" + nameof(DebuggerDisplay) + "}")]
+	private class View : IServiceBroker, IRemoteServiceBroker
+	{
+		/// <summary>
+		/// The owner of this view.
+		/// </summary>
+		private readonly GlobalBrokeredServiceContainer container;
+		private readonly IReadOnlyDictionary<string, string> clientCredentials;
+		private readonly ClientCredentialsPolicy clientCredentialsPolicy;
+		private readonly CultureInfo? clientCulture;
+		private readonly CultureInfo? clientUICulture;
+
+		/// <summary>
+		/// The set of services that have been queried for (whether or not they were found)
+		/// since the last time the <see cref="AvailabilityChanged"/> event has been raised regarding them.
+		/// </summary>
+		private readonly HashSet<ServiceMoniker> observedServices = new HashSet<ServiceMoniker>();
+
+		private EventHandler<BrokeredServicesChangedEventArgs>? availabilityChanged;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="View"/> class.
+		/// </summary>
+		/// <param name="container">The parent container.</param>
+		/// <param name="audience">
+		/// The audience for this <see cref="IServiceBroker"/>.
+		/// Each flag specified applies an additional filter (i.e. fewer exposed services).
+		/// Use <see cref="ServiceAudience.None"/> to make *all* services available (to be used for local consumption only).
+		/// </param>
+		/// <param name="clientCredentials">The client credentials to apply to incoming requests.</param>
+		/// <param name="clientCredentialsPolicy">Specifies which client credentials prevails when the service request contains non-empty credentials.</param>
+		/// <param name="clientCulture">The value to apply to service requests when <see cref="ServiceActivationOptions.ClientCulture"/> is <see langword="null"/>.</param>
+		/// <param name="clientUICulture">The value to apply to service requests when <see cref="ServiceActivationOptions.ClientUICulture"/> is <see langword="null"/>.</param>
+		protected internal View(GlobalBrokeredServiceContainer container, ServiceAudience audience, IReadOnlyDictionary<string, string> clientCredentials, ClientCredentialsPolicy clientCredentialsPolicy, CultureInfo? clientCulture = null, CultureInfo? clientUICulture = null)
+		{
+			this.container = container ?? throw new ArgumentNullException(nameof(container));
+			this.Audience = audience;
+			this.clientCredentials = clientCredentials ?? throw new ArgumentNullException(nameof(clientCredentials));
+			this.clientCredentialsPolicy = clientCredentialsPolicy;
+			this.clientCulture = clientCulture;
+			this.clientUICulture = clientUICulture;
+		}
+
+		/// <inheritdoc />
+		public event EventHandler<BrokeredServicesChangedEventArgs>? AvailabilityChanged
+		{
+			add
+			{
+				lock (this.SyncObject)
+				{
+					if (this.availabilityChanged == null)
+					{
+						// Wire our own handler up to the service container
+						this.container.AvailabilityChanged += this.OnAvailabilityChanged;
+					}
+
+					this.availabilityChanged += value;
+				}
+			}
+
+			remove
+			{
+				lock (this.SyncObject)
+				{
+					this.availabilityChanged -= value;
+
+					if (this.availabilityChanged == null)
+					{
+						// Unadvise for events from the service container so we neither leak nor require the owner to dispose of us.
+						this.container.AvailabilityChanged -= this.OnAvailabilityChanged;
+					}
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets the filter to apply to services.
+		/// </summary>
+		internal ServiceAudience Audience { get; }
+
+		/// <summary>
+		/// Gets an object that this class can lock on to synchronize field access.
+		/// </summary>
+		/// <remarks>
+		/// We return a private field because that's good enough, and it avoids an extra allocation of a dedicated sync object.
+		/// </remarks>
+		private object SyncObject => this.observedServices;
+
+		[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+		private string DebuggerDisplay => $"{this.Audience} view";
+
+		/// <inheritdoc />
+		public virtual async ValueTask<IDuplexPipe?> GetPipeAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions options, CancellationToken cancellationToken)
+		{
+			Requires.NotNull(serviceMoniker, nameof(serviceMoniker));
+
+			using StartActivityExtension.TraceActivity activity = this.container.traceSource.StartActivity("Requesting pipe to \"{0}\"", serviceMoniker);
+
+			var proffered = default(IProffered);
+			MissingBrokeredServiceErrorCode errorCode;
+			RequestResult requestResult = RequestResult.Declined;
+
+			try
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+				options = this.ApplyOptionsFilter(options);
+
+				(proffered, errorCode) = await this.TryGetProfferingSourceAsync(serviceMoniker, cancellationToken).ConfigureAwait(false);
+
+				if (proffered is object)
+				{
+					IDuplexPipe? pipe = proffered is ProfferedViewIntrinsicService viewIntrinsic
+						? await viewIntrinsic.GetPipeAsync(this, serviceMoniker, options, cancellationToken).ConfigureAwait(false)
+						: await proffered.GetPipeAsync(serviceMoniker, options, cancellationToken).ConfigureAwait(false);
+
+					TraceEventType eventType = TraceEventType.Warning;
+					if (pipe is object)
+					{
+						eventType = TraceEventType.Information;
+						requestResult = RequestResult.Fulfilled;
+					}
+					else
+					{
+						errorCode = MissingBrokeredServiceErrorCode.ServiceFactoryReturnedNull;
+					}
+
+					if (this.container.traceSource.Switch.ShouldTrace(eventType))
+					{
+						this.container.traceSource.TraceEvent(
+							eventType,
+							(int)TraceEvents.Request,
+							"Request for pipe to \"{0}\" is {1} by {2}: {3}.",
+							serviceMoniker,
+							requestResult,
+							proffered.Source,
+							errorCode);
+					}
+
+					return pipe;
+				}
+				else
+				{
+					requestResult = RequestResult.DeclinedNotFound;
+
+					if (this.container.traceSource.Switch.ShouldTrace(TraceEventType.Warning))
+					{
+						this.container.traceSource.TraceEvent(
+						TraceEventType.Warning,
+						(int)TraceEvents.Request,
+						"Request for pipe to \"{0}\" is declined: {1}.",
+						serviceMoniker,
+						errorCode);
+					}
+				}
+
+				return default;
+			}
+			catch (Exception ex) when (!(ex is ServiceActivationFailedException) && !(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
+			{
+				var outer = new ServiceActivationFailedException(serviceMoniker, ex);
+				this.container.traceSource.TraceEvent(TraceEventType.Error, (int)TraceEvents.Request, "{0}", outer);
+				throw outer;
+			}
+			catch (ServiceActivationFailedException ex)
+			{
+				this.container.traceSource.TraceEvent(TraceEventType.Error, (int)TraceEvents.Request, "{0}", ex);
+				throw;
+			}
+			finally
+			{
+				this.container.OnRequestHandled(serviceMoniker, (proffered as ProfferedServiceFactory)?.Descriptor, RequestType.Pipe, requestResult, proffered);
+
+				// Record the client's interest in this service.
+				// We do this after actually acquiring the service so that if an AvailabilityChanged event was raised *during* the request,
+				// which can sometimes happen if the very act of requesting the service changes the service graph,
+				// the client will get an event if the service changes *after* we reached this point.
+				// We also want to avoid the mid-request event being raised to the client if it's just from loading a package
+				// since that can cause the client to dispose the service we just acquired and re-request it.
+				// If we ever need to address the race condition of a proffered service changing *during* acquisition,
+				// we should be careful to avoid propagating events to the client unless it really is important/relevant/new.
+				lock (this.SyncObject)
+				{
+					this.observedServices.Add(serviceMoniker);
+				}
+			}
+		}
+
+		/// <inheritdoc />
+		public virtual async ValueTask<T?> GetProxyAsync<T>(ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options, CancellationToken cancellationToken)
+			where T : class
+		{
+			Requires.NotNull(serviceDescriptor, nameof(serviceDescriptor));
+
+			using StartActivityExtension.TraceActivity activity = this.container.traceSource.StartActivity("Requesting proxy to \"{0}\"", serviceDescriptor.Moniker);
+
+			var proffered = default(IProffered);
+			MissingBrokeredServiceErrorCode errorCode;
+			RequestResult requestResult = RequestResult.Declined;
+
+			try
+			{
+				cancellationToken.ThrowIfCancellationRequested();
+				options = this.ApplyOptionsFilter(options);
+
+				(proffered, errorCode) = await this.TryGetProfferingSourceAsync(serviceDescriptor.Moniker, cancellationToken).ConfigureAwait(false);
+				if (proffered is object)
+				{
+					serviceDescriptor = serviceDescriptor
+						.WithTraceSource(await this.container.GetTraceSourceForConnectionAsync(this, serviceDescriptor.Moniker, options, clientRole: true, cancellationToken).ConfigureAwait(false));
+
+					GC.KeepAlive(typeof(ValueTask<T>)); // workaround CLR bug https://dev.azure.com/devdiv/DevDiv/_workitems/edit/1358442
+					T? proxy = proffered is ProfferedViewIntrinsicService viewIntrinsic
+						? await viewIntrinsic.GetProxyAsync<T>(this, serviceDescriptor, options, cancellationToken).ConfigureAwait(false)
+						: await proffered.GetProxyAsync<T>(serviceDescriptor, options, cancellationToken).ConfigureAwait(false);
+
+					TraceEventType eventType = TraceEventType.Warning;
+					if (proxy is object)
+					{
+						eventType = TraceEventType.Information;
+						requestResult = RequestResult.Fulfilled;
+					}
+					else
+					{
+						errorCode = MissingBrokeredServiceErrorCode.ServiceFactoryReturnedNull;
+					}
+
+					if (this.container.traceSource.Switch.ShouldTrace(eventType))
+					{
+						this.container.traceSource.TraceEvent(
+							eventType,
+							(int)TraceEvents.Request,
+							"Request for proxy to \"{0}\" is {1} by {2}: {3}.",
+							serviceDescriptor.Moniker,
+							requestResult,
+							proffered.Source,
+							errorCode);
+					}
+
+					return proxy;
+				}
+				else
+				{
+					requestResult = RequestResult.DeclinedNotFound;
+
+					if (this.container.traceSource.Switch.ShouldTrace(TraceEventType.Warning))
+					{
+						this.container.traceSource.TraceEvent(
+							TraceEventType.Warning,
+							(int)TraceEvents.Request,
+							"Request for proxy to \"{0}\" is declined: {1}.",
+							serviceDescriptor.Moniker,
+							errorCode);
+					}
+				}
+
+				return default;
+			}
+			catch (Exception ex) when (!(ex is ServiceActivationFailedException) && !(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
+			{
+				var outer = new ServiceActivationFailedException(serviceDescriptor.Moniker, ex);
+				this.container.traceSource.TraceEvent(TraceEventType.Error, (int)TraceEvents.Request, "{0}", outer);
+				throw outer;
+			}
+			catch (ServiceActivationFailedException ex)
+			{
+				this.container.traceSource.TraceEvent(TraceEventType.Error, (int)TraceEvents.Request, "{0}", ex);
+				throw;
+			}
+			finally
+			{
+				this.container.OnRequestHandled(serviceDescriptor.Moniker, serviceDescriptor, RequestType.Proxy, requestResult, proffered);
+
+				// Record the client's interest in this service.
+				// We do this after actually acquiring the service so that if an AvailabilityChanged event was raised *during* the request,
+				// which can sometimes happen if the very act of requesting the service changes the service graph,
+				// the client will get an event if the service changes *after* we reached this point.
+				// We also want to avoid the mid-request event being raised to the client if it's just from loading a package
+				// since that can cause the client to dispose the service we just acquired and re-request it.
+				// If we ever need to address the race condition of a proffered service changing *during* acquisition,
+				// we should be careful to avoid propagating events to the client unless it really is important/relevant/new.
+				lock (this.SyncObject)
+				{
+					this.observedServices.Add(serviceDescriptor.Moniker);
+				}
+			}
+		}
+
+		/// <inheritdoc />
+		public Task HandshakeAsync(ServiceBrokerClientMetadata clientMetadata, CancellationToken cancellationToken)
+		{
+			if (!clientMetadata.SupportedConnections.HasFlag(RemoteServiceConnections.IpcPipe))
+			{
+				// We only support pipes.
+				throw new NotSupportedException();
+			}
+
+			return Task.CompletedTask;
+		}
+
+		/// <inheritdoc />
+		public async Task<RemoteServiceConnectionInfo> RequestServiceChannelAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions serviceActivationOptions, CancellationToken cancellationToken)
+		{
+			Requires.NotNull(serviceMoniker, nameof(serviceMoniker));
+			serviceActivationOptions = this.ApplyOptionsFilter(serviceActivationOptions);
+
+			try
+			{
+				(IProffered? proffered, MissingBrokeredServiceErrorCode errorCode) = await this.TryGetProfferingSourceAsync(serviceMoniker, cancellationToken).ConfigureAwait(false);
+				if (proffered is object)
+				{
+					RemoteServiceConnectionInfo connectionInfo = proffered is ProfferedViewIntrinsicService viewIntrinsic
+						? await viewIntrinsic.RequestServiceChannelAsync(this, serviceMoniker, serviceActivationOptions, cancellationToken).ConfigureAwait(false)
+						: await proffered.RequestServiceChannelAsync(serviceMoniker, serviceActivationOptions, cancellationToken).ConfigureAwait(false);
+					return connectionInfo;
+				}
+
+				if (this.container.traceSource.Switch.ShouldTrace(TraceEventType.Warning))
+				{
+					this.container.traceSource.TraceEvent(
+						TraceEventType.Warning,
+						(int)TraceEvents.Request,
+						"Remote request for \"{0}\" is declined: {1}.",
+						serviceMoniker,
+						errorCode);
+				}
+
+				return default;
+			}
+			finally
+			{
+				// Record the client's interest in this service.
+				// We do this after actually acquiring the service so that if an AvailabilityChanged event was raised *during* the request,
+				// which can sometimes happen if the very act of requesting the service changes the service graph,
+				// the client will get an event if the service changes *after* we reached this point.
+				// We also want to avoid the mid-request event being raised to the client if it's just from loading a package
+				// since that can cause the client to dispose the service we just acquired and re-request it.
+				// If we ever need to address the race condition of a proffered service changing *during* acquisition,
+				// we should be careful to avoid propagating events to the client unless it really is important/relevant/new.
+				lock (this.SyncObject)
+				{
+					this.observedServices.Add(serviceMoniker);
+				}
+			}
+		}
+
+		/// <inheritdoc />
+		public async Task CancelServiceRequestAsync(Guid serviceRequestId)
+		{
+			// Try sending the cancellation to all remote sources since we don't know which one actually handled the request
+			// that's being canceled. Checking if a request should be canceled by the broker should be relatively cheap and
+			// since request ids are guids there's no risk of id collisions
+			foreach (IProffered proffered in this.container.remoteSources.Values)
+			{
+				await proffered.CancelServiceRequestAsync(serviceRequestId).ConfigureAwait(false);
+			}
+		}
+
+		/// <summary>
+		/// Raises the <see cref="IServiceBroker.AvailabilityChanged"/> event.
+		/// </summary>
+		/// <param name="sender">Unused.</param>
+		/// <param name="args">The arguments for the event. The set of impacted services must be a hash-based collection so we can use Intersect on it.</param>
+		internal void OnAvailabilityChanged(object? sender, (ImmutableDictionary<ServiceSource, ImmutableDictionary<ServiceMoniker, IProffered>>? OldIndex, ImmutableHashSet<ServiceMoniker> ImpactedServices) args)
+		{
+			EventHandler<BrokeredServicesChangedEventArgs>? availabilityChanged = this.availabilityChanged;
+			if (availabilityChanged == null)
+			{
+				// No one cares.
+				return;
+			}
+
+			ImmutableDictionary<ServiceSource, ImmutableDictionary<ServiceMoniker, IProffered>>? oldIndex = args.OldIndex;
+			ImmutableHashSet<ServiceMoniker> impactedServices = args.ImpactedServices;
+
+			// Filter down to just those services that our client has asked about.
+			IImmutableSet<ServiceMoniker> impactedAndObservedServices;
+			lock (this.SyncObject)
+			{
+				// Record which services were both impacted by the sender and observed by this view.
+				impactedAndObservedServices = impactedServices.Intersect(this.observedServices);
+
+				// Remove the impacted services from our observed collection since we're raising a changed event now.
+				// No more events will be raised regarding these impacted services unless they are queried for again.
+				this.observedServices.ExceptWith(impactedAndObservedServices);
+			}
+
+			if (oldIndex != null)
+			{
+				// This change came from a change to the proffering tables (not just an backing service broker internal change).
+				// Further filter down by verifying that the proffering source for each service was *actually* impacted.
+				// If a local service proffering changed, but we're connected to a remote environment where the service is expected to come from,
+				// then there's no meaningful change to the service from the consumer's perspective for example.
+				foreach (ServiceMoniker moniker in impactedAndObservedServices)
+				{
+					bool oldResult = this.container.TryGetProfferingSource(oldIndex, moniker, this.Audience, out IProffered? oldProffered, out _);
+					bool newResult = this.container.TryGetProfferingSource(moniker, this.Audience, out IProffered? newProffered, out _);
+					if (oldResult == newResult && oldProffered == newProffered)
+					{
+						// The source of this service hasn't actually changed, so don't tell consumers that it has.
+						impactedAndObservedServices = impactedAndObservedServices.Remove(moniker);
+					}
+				}
+			}
+
+			if (impactedAndObservedServices.Count == 0)
+			{
+				// Avoid raising the event if it's essentially empty after we've applied our filter.
+				return;
+			}
+
+			// We do not filter the monikers to just those the client is privileged to see, because they've already asked about the service
+			// since they asked about it earlier. And it's possible that the change to the service is a proffering change where the availability for this client changed.
+			try
+			{
+				availabilityChanged.Invoke(this, new BrokeredServicesChangedEventArgs(impactedAndObservedServices, otherServicesImpacted: false));
+			}
+			catch
+			{
+				// TODO: report failures as a fault in telemetry.
+			}
+		}
+
+		internal async ValueTask<(IProffered? ProfferingSource, MissingBrokeredServiceErrorCode ErrorCode)> TryGetProfferingSourceAsync(ServiceMoniker serviceMoniker, CancellationToken cancellationToken)
+		{
+			if (this.container.TryGetProfferingSource(serviceMoniker, this.Audience, out IProffered? proffered, out MissingBrokeredServiceErrorCode errorCode))
+			{
+				return (proffered, errorCode);
+			}
+
+			if (errorCode == MissingBrokeredServiceErrorCode.ServiceFactoryNotProffered)
+			{
+				if (await this.LoadProfferingPackageAsync(serviceMoniker, cancellationToken).ConfigureAwait(false))
+				{
+					if (this.container.TryGetProfferingSource(serviceMoniker, this.Audience, out proffered, out errorCode))
+					{
+						return (proffered, errorCode);
+					}
+				}
+			}
+
+			return (null, errorCode);
+		}
+
+		private async Task<bool> LoadProfferingPackageAsync(ServiceMoniker serviceMoniker, CancellationToken cancellationToken)
+		{
+			if (!this.container.TryLookupServiceRegistration(serviceMoniker, out ServiceRegistration? serviceRegistration, out _)
+				|| serviceRegistration.ProfferingPackageId is null)
+			{
+				if (this.container.traceSource.Switch.ShouldTrace(TraceEventType.Warning))
+				{
+					this.container.traceSource.TraceEvent(TraceEventType.Warning, (int)TraceEvents.LoadPackage, "Brokered service \"{0}\" has no proffering source and no package registered to load.", serviceMoniker);
+				}
+
+				return false;
+			}
+
+			// We found the service and its proffering package. Only load the package if the client has access to the service.
+			if (!serviceRegistration.IsExposedTo(this.Audience))
+			{
+				if (this.container.traceSource.Switch.ShouldTrace(TraceEventType.Warning))
+				{
+					this.container.traceSource.TraceEvent(
+						TraceEventType.Warning,
+						(int)TraceEvents.LoadPackage,
+						"Proffering package for brokered service \"{0}\" will not be loaded because the requesting party ({1}) isn't allowed to call this service (with audience {2}) anyway.",
+						serviceMoniker,
+						this.Audience,
+						serviceRegistration.Audience);
+				}
+
+				return false;
+			}
+
+			// Perf optimization: skip all the work if we've already done it for this moniker before.
+			if (this.container.IsPackageLoaded(serviceRegistration.ProfferingPackageId) || serviceRegistration.ProfferingPackageId is null)
+			{
+				return false;
+			}
+
+			await serviceRegistration.LoadProfferingPackageAsync(cancellationToken).ConfigureAwait(false);
+			this.container.RecordPackageLoaded(serviceRegistration.ProfferingPackageId);
+
+			if (this.container.traceSource.Switch.ShouldTrace(TraceEventType.Information))
+			{
+				this.container.traceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.LoadPackage, "Proffering package {0} for brokered service \"{1}\" is now loaded.", serviceRegistration.ProfferingPackageId, serviceMoniker);
+			}
+
+			return true;
+		}
+
+		private ServiceActivationOptions ApplyOptionsFilter(ServiceActivationOptions options)
+		{
+			if (this.clientCredentialsPolicy == ClientCredentialsPolicy.FilterOverridesRequest || (options.ClientCredentials?.Count ?? 0) == 0)
+			{
+				options.ClientCredentials = this.clientCredentials;
+			}
+
+			options.ClientCulture ??= this.clientCulture;
+			options.ClientUICulture ??= this.clientUICulture;
+
+			return options;
+		}
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.cs
@@ -1,0 +1,802 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.ServiceHub.Framework.Services;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+using Microsoft.VisualStudio.Threading;
+using Nerdbank.Streams;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+/// <summary>
+/// A container of brokered services that supports multiple service sources and multiple consumer roles that get filtered <see cref="IServiceBroker"/> views into the available services.
+/// </summary>
+/// <remarks>
+/// <para>When a service is registered without a version, it doubles as a fallback service when a request for that service name is made but no exact version match can be found.</para>
+/// </remarks>
+public abstract partial class GlobalBrokeredServiceContainer : IBrokeredServiceContainer, IBrokeredServiceContainerInternal, IBrokeredServiceContainerDiagnostics
+{
+	/// <summary>
+	/// Defines the order of sources to check for remote services.
+	/// </summary>
+	private static readonly ServiceSource[] PreferredSourceOrderForRemoteServices = new ServiceSource[] { ServiceSource.TrustedExclusiveClient, ServiceSource.TrustedExclusiveServer, ServiceSource.TrustedServer, ServiceSource.UntrustedServer };
+
+	/// <summary>
+	/// Defines the order of sources to check for locally proffered services.
+	/// </summary>
+	private static readonly ServiceSource[] PreferredSourceOrderForLocalServices = new ServiceSource[] { ServiceSource.SameProcess, ServiceSource.OtherProcessOnSameMachine };
+
+	private readonly object syncObject = new object();
+
+	private readonly HashSet<object> loadedPackageIds = new HashSet<object>();
+
+	private readonly TraceSource traceSource;
+
+	private readonly JoinableTaskFactory? joinableTaskFactory;
+
+	/// <summary>
+	/// A dictionary of registered services, keyed by their monikers.
+	/// </summary>
+	private ImmutableDictionary<ServiceMoniker, ServiceRegistration> registeredServices;
+
+	/// <summary>
+	/// A value indicating whether this process is dedicated as a client of a Codespace.
+	/// </summary>
+	/// <remarks>
+	/// If we're running in a Codespace client, block all local services that may be obtained from the Codespace server.
+	/// </remarks>
+	private bool isClientOfExclusiveServer;
+
+	/// <summary>
+	/// A dictionary for looking up a proffered service by a source and moniker.
+	/// </summary>
+	private ImmutableDictionary<ServiceSource, ImmutableDictionary<ServiceMoniker, IProffered>> profferedServiceIndex = ImmutableDictionary<ServiceSource, ImmutableDictionary<ServiceMoniker, IProffered>>.Empty;
+
+	/// <summary>
+	/// The remote sources from which we can expect services and the proffering sources for them.
+	/// </summary>
+	private ImmutableDictionary<ServiceSource, IProffered> remoteSources = ImmutableDictionary<ServiceSource, IProffered>.Empty;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GlobalBrokeredServiceContainer"/> class.
+	/// </summary>
+	/// <param name="services">
+	/// A map of service monikers to their registration details.
+	/// Only registered services will be obtainable from the <see cref="IServiceBroker"/> returned from methods on this class.
+	/// </param>
+	/// <param name="isClientOfExclusiveServer"><see langword="true"/> when this process is or will be connected to a dedicated, trusted server (e.g. a Codespace) that will provide the environment to this client; <see langword="false"/> otherwise.</param>
+	/// <param name="joinableTaskFactory">An optional <see cref="JoinableTaskFactory"/> to use when scheduling async work, to avoid deadlocks in an application with a main thread.</param>
+	/// <param name="traceSource">A means of logging.</param>
+	protected GlobalBrokeredServiceContainer(ImmutableDictionary<ServiceMoniker, ServiceRegistration> services, bool isClientOfExclusiveServer, JoinableTaskFactory? joinableTaskFactory, TraceSource traceSource)
+	{
+		this.registeredServices = services;
+		this.isClientOfExclusiveServer = isClientOfExclusiveServer;
+		this.joinableTaskFactory = joinableTaskFactory;
+		this.traceSource = traceSource;
+
+		// Add built-in services.
+		this.registeredServices = this.registeredServices.Add(
+			FrameworkServices.RemoteBrokeredServiceManifest.Moniker,
+			new ServiceRegistration((ServiceAudience.RemoteExclusiveServer | ServiceAudience.AllClientsIncludingGuests) & ~ServiceAudience.Local, null, allowGuestClients: true));
+		this.registeredServices = this.registeredServices.Add(
+			MissingServiceDiagnostics.Moniker,
+			new ServiceRegistration(ServiceAudience.Local, null, allowGuestClients: false));
+		this.Proffer(new ProfferedViewIntrinsicService(this, FrameworkServices.RemoteBrokeredServiceManifest, (view, mk, options, sb, ct) => new ValueTask<object?>(new BrokeredServiceManifest(this, view.Audience))));
+		this.Proffer(new ProfferedViewIntrinsicService(this, MissingServiceDiagnostics, (view, mk, options, sb, ct) => new ValueTask<object?>(new MissingServiceDiagnosticsService(view))));
+	}
+
+	private event EventHandler<(ImmutableDictionary<ServiceSource, ImmutableDictionary<ServiceMoniker, IProffered>>?, ImmutableHashSet<ServiceMoniker>)>? AvailabilityChanged;
+
+	/// <summary>
+	/// Gets a descriptor for the service that can diagnose the cause of a missing brokered service.
+	/// Use <see cref="IMissingServiceDiagnosticsService"/> to interact with this service.
+	/// </summary>
+	public static ServiceRpcDescriptor MissingServiceDiagnostics { get; } = new ServiceJsonRpcDescriptor(
+		new ServiceMoniker("Microsoft.VisualStudio.GlobalBrokeredServiceContainer.MissingServiceDiagnostics", new Version(1, 0)),
+		ServiceJsonRpcDescriptor.Formatters.MessagePack,
+		ServiceJsonRpcDescriptor.MessageDelimiters.BigEndianInt32LengthHeader);
+
+	/// <inheritdoc />
+	public abstract IReadOnlyDictionary<string, string> LocalUserCredentials { get; }
+
+	/// <summary>
+	/// Gets the services currently registered.
+	/// </summary>
+	protected ImmutableDictionary<ServiceMoniker, ServiceRegistration> RegisteredServices => this.registeredServices;
+
+	/// <inheritdoc />
+	public IDisposable Proffer(ServiceRpcDescriptor serviceDescriptor, BrokeredServiceFactory factory) => this.Proffer(new ProfferedServiceFactory(this, serviceDescriptor, factory));
+
+	/// <inheritdoc />
+	public IDisposable Proffer(ServiceRpcDescriptor serviceDescriptor, AuthorizingBrokeredServiceFactory factory) => this.Proffer(new ProfferedServiceFactory(this, serviceDescriptor, factory));
+
+	/// <summary>
+	/// Proffers services from another <see cref="IServiceBroker"/> into this container.
+	/// </summary>
+	/// <param name="serviceBroker">A service broker offering local services.</param>
+	/// <param name="serviceMonikers">The monikers to services that should be obtained from this <paramref name="serviceBroker"/>.</param>
+	/// <returns>A value that can be disposed to remove this <paramref name="serviceBroker"/> from the container.</returns>
+	public IDisposable Proffer(IServiceBroker serviceBroker, IReadOnlyCollection<ServiceMoniker> serviceMonikers) => this.Proffer(new ProfferedServiceBroker(this, serviceBroker, ServiceSource.SameProcess, serviceMonikers));
+
+#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
+
+	/// <summary>
+	/// Proffers services offered by a remote <see cref="IServiceBroker"/> for access by this container.
+	/// </summary>
+	/// <param name="serviceBroker">The service broker for remote services.</param>
+	/// <param name="source">Where the remote services that are being proffered come from.</param>
+	/// <param name="serviceMonikers">
+	/// The set of service monikers that may be requested of this service broker. May be null for truly remote brokers that we don't know the full set of services for.
+	/// Only services registered with this container will ever be requested from this <paramref name="serviceBroker"/>.
+	/// </param>
+	/// <returns>A value that can be disposed to remove this <paramref name="serviceBroker"/> from the container.</returns>
+	public IDisposable ProfferRemoteBroker(IServiceBroker serviceBroker, ServiceSource source, ImmutableHashSet<ServiceMoniker>? serviceMonikers = null)
+	{
+		Requires.NotNull(serviceBroker, nameof(serviceBroker));
+		Requires.Argument(source != ServiceSource.SameProcess, nameof(source), "Use the public {0} method to proffer services from the same process.", nameof(IBrokeredServiceContainer.Proffer));
+
+		this.traceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.Proffered, "IServiceBroker proffered from remote source: {0}.", source);
+		return this.Proffer(new ProfferedServiceBroker(this, serviceBroker, source, this.GetAllowedMonikers(source, serviceMonikers)));
+	}
+
+	/// <summary>
+	/// Proffers services offered by a remote <see cref="IRemoteServiceBroker"/> for access by this container.
+	/// </summary>
+	/// <inheritdoc cref="ProfferRemoteBroker(IServiceBroker, ServiceSource, ImmutableHashSet{ServiceMoniker}?)"/>
+	public IDisposable ProfferRemoteBroker(IRemoteServiceBroker serviceBroker, ServiceSource source, ImmutableHashSet<ServiceMoniker>? serviceMonikers = null)
+		=> this.ProfferRemoteBroker(serviceBroker, null, source, serviceMonikers);
+
+	/// <summary>
+	/// Proffers services offered by a remote <see cref="IRemoteServiceBroker"/> for access by this container.
+	/// </summary>
+	/// <inheritdoc cref="ProfferRemoteBroker(IServiceBroker, ServiceSource, ImmutableHashSet{ServiceMoniker}?)"/>
+	/// <param name="serviceBroker"><inheritdoc cref="ProfferRemoteBroker(IServiceBroker, ServiceSource, ImmutableHashSet{ServiceMoniker}?)" path="/param[@name='serviceBroker]"/></param>
+	/// <param name="multiplexingStream">An optional <see cref="MultiplexingStream"/> that may be used to provision pipes for each brokered service.</param>
+	/// <param name="source"><inheritdoc cref="ProfferRemoteBroker(IServiceBroker, ServiceSource, ImmutableHashSet{ServiceMoniker}?)" path="/param[@name='source]"/></param>
+	/// <param name="serviceMonikers"><inheritdoc cref="ProfferRemoteBroker(IServiceBroker, ServiceSource, ImmutableHashSet{ServiceMoniker}?)" path="/param[@name='serviceMonikers]"/></param>
+	public IDisposable ProfferRemoteBroker(IRemoteServiceBroker serviceBroker, MultiplexingStream? multiplexingStream, ServiceSource source, ImmutableHashSet<ServiceMoniker>? serviceMonikers = null)
+	{
+		Requires.NotNull(serviceBroker, nameof(serviceBroker));
+		Requires.Argument(source != ServiceSource.SameProcess, nameof(source), "Use the public {0} method to proffer services from the same process.", nameof(IBrokeredServiceContainer.Proffer));
+
+		this.traceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.Proffered, "IRemoteServiceBroker proffered from remote source: {0}.", source);
+		return this.Proffer(new ProfferedRemoteServiceBroker(this, serviceBroker, multiplexingStream, source, this.GetAllowedMonikers(source, serviceMonikers)));
+	}
+
+#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
+
+	/// <inheritdoc />
+	public IServiceBroker GetFullAccessServiceBroker()
+	{
+		return new View(this, ServiceAudience.Process, this.LocalUserCredentials, ClientCredentialsPolicy.RequestOverridesDefault);
+	}
+
+	/// <inheritdoc />
+	public IServiceBroker GetLimitedAccessServiceBroker(ServiceAudience audience, IReadOnlyDictionary<string, string> clientCredentials, ClientCredentialsPolicy credentialPolicy)
+	{
+		return new View(this, audience, clientCredentials, credentialPolicy);
+	}
+
+	/// <inheritdoc cref="GetLimitedAccessServiceBroker(ServiceAudience, IReadOnlyDictionary{string, string}, ClientCredentialsPolicy)" />
+	/// <returns>A <see cref="IRemoteServiceBroker"/> for use in sharing directly on a remote connection.</returns>
+	public IRemoteServiceBroker GetLimitedAccessRemoteServiceBroker(ServiceAudience audience, IReadOnlyDictionary<string, string> clientCredentials, ClientCredentialsPolicy credentialPolicy)
+	{
+		return new View(this, audience, clientCredentials, credentialPolicy);
+	}
+
+	/// <summary>
+	/// Writes a bunch of diagnostic data to a JSON file.
+	/// </summary>
+	/// <param name="filePath">The path to the JSON file to be written. If it already exists it will be overwritten.</param>
+	/// <param name="serviceAudience">The audience.</param>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>A task that completes when the writing is done.</returns>
+	/// <remarks>
+	/// Rough schema of JSON file:
+	/// <code><![CDATA[
+	///  {
+	///    "perspectiveAudience": "Process",
+	///    "activeRemoteSources" : [ "TrustedServer" ],
+	///    "brokeredServices": [
+	///      {
+	///        name: "Calculator",
+	///        version: "1.0",
+	///        audience: "Local, Process, Guest",
+	///        allowGuestClients: false,
+	///        profferingPackage: "{28074D43-B498-47FE-97CF-4A182DA71C59}"
+	///        profferedLocally: true,
+	///        activeSource: "TrustedServer",
+	///        includedByRemoteSourceManifest: true
+	///      },
+	///      {
+	///        // ...
+	///      },
+	///      // ...
+	///    ]
+	///  }
+	/// ]]></code>
+	/// </remarks>
+	public async Task ExportDiagnosticsAsync(string filePath, ServiceAudience serviceAudience, CancellationToken cancellationToken = default)
+	{
+		using var jsonWriter = new JsonTextWriter(new StreamWriter(new FileStream(filePath, FileMode.Create, FileAccess.Write, FileShare.None, 2048, useAsync: true), Encoding.UTF8, 2048))
+		{
+			Formatting = Formatting.Indented,
+		};
+
+		JObject json = await this.GetDiagnosticsAsync(serviceAudience, cancellationToken).ConfigureAwait(false);
+		await json.WriteToAsync(jsonWriter).ConfigureAwait(false);
+	}
+
+	/// <summary>
+	/// Returns the services that are registered locally that *may* be proffered by a particular remote source.
+	/// </summary>
+	/// <param name="remoteSource">The source of services.</param>
+	/// <returns>A sequence of registered services that we may expect from the source.</returns>
+	public IEnumerable<ServiceMoniker> GetServicesThatMayBeExpected(ServiceSource remoteSource)
+	{
+		foreach (KeyValuePair<ServiceMoniker, ServiceRegistration> tuple in this.registeredServices)
+		{
+			if (tuple.Value.IsExposedTo(ConvertRemoteSourceToLocalAudience(remoteSource)))
+			{
+				yield return tuple.Key;
+			}
+		}
+	}
+
+	/// <summary>
+	/// Gets a service broker that may be provided to a <see cref="BrokeredServiceFactory"/>
+	/// in order to automatically propagate <see cref="ServiceActivationOptions.ClientCredentials"/> from one service to its dependencies.
+	/// </summary>
+	/// <param name="options">The options passed to the originally requested service.</param>
+	/// <returns>The filtering, authorizing service broker.</returns>
+	public IServiceBroker GetSecureServiceBroker(ServiceActivationOptions options)
+	{
+		ClientCredentialsPolicy policy = ClientCredentialsPolicy.RequestOverridesDefault; // Apply client credentials where none are given to match that of the caller.
+		return new View(this, ServiceAudience.Process, options.ClientCredentials ?? ImmutableDictionary<string, string>.Empty, policy, options.ClientCulture, options.ClientUICulture);
+	}
+
+	/// <inheritdoc cref="GetTraceSourceForConnectionAsync(IServiceBroker, ServiceMoniker, ServiceActivationOptions, bool, CancellationToken)"/>
+	/// <devremarks>
+	/// This method was created because <see cref="GetTraceSourceForConnectionAsync(IServiceBroker, ServiceMoniker, ServiceActivationOptions, bool, CancellationToken)"/>
+	/// needed to be exposed publicly but as a protected virtual method, making it public would be a binary breaking change.
+	/// </devremarks>
+	public ValueTask<TraceSource?> GetTraceSourceForBrokeredServiceAsync(IServiceBroker serviceBroker, ServiceMoniker serviceMoniker, ServiceActivationOptions options, bool clientRole, CancellationToken cancellationToken) => this.GetTraceSourceForConnectionAsync(serviceBroker, serviceMoniker, options, clientRole, cancellationToken);
+
+	/// <summary>
+	/// Registers a set of services with the global broker. This is separate from proffering a service. A service should be registered before it is proffered.
+	/// An <see cref="IServiceBroker.AvailabilityChanged"/> event is never
+	/// fired as a result of calling this method, but instead will be fired once the service is proffered.
+	/// </summary>
+	/// <param name="services">The set of services to be registered.</param>
+	protected internal void RegisterServices(IReadOnlyDictionary<ServiceMoniker, ServiceRegistration> services)
+	{
+		if (services.Count == 0)
+		{
+			return;
+		}
+
+		lock (this.syncObject)
+		{
+			foreach (KeyValuePair<ServiceMoniker, ServiceRegistration> service in services)
+			{
+				if (!this.registeredServices.ContainsKey(service.Key))
+				{
+					ImmutableInterlocked.TryAdd(ref this.registeredServices, service.Key, service.Value);
+				}
+				else
+				{
+					this.traceSource.TraceEvent(TraceEventType.Warning, (int)TraceEvents.Registered, "Service '{0}' has already been registered. Skipping duplicate registration.", service.Key);
+				}
+			}
+		}
+	}
+
+	/// <summary>
+	/// Proffers a new Intrinsic service. Should only be accessible to derived classes.
+	/// </summary>
+	/// <param name="serviceDescriptor">The <see cref="ServiceRpcDescriptor"/> of the service.</param>
+	/// <param name="newRegistration">The <see cref="ServiceRegistration"/> representing the service being registered.</param>
+	/// <param name="factory">The <see cref="BrokeredServiceFactory"/> that generates the new service.</param>
+	/// <returns>An <see cref="IDisposable"/> that will remove the service when disposed.</returns>
+	protected IDisposable ProfferIntrinsicService(ServiceRpcDescriptor serviceDescriptor, ServiceRegistration newRegistration, BrokeredServiceFactory factory)
+	{
+		this.registeredServices = this.registeredServices.Add(serviceDescriptor.Moniker, newRegistration);
+		return this.Proffer(new ProfferedViewIntrinsicService(this, serviceDescriptor, (view, mk, options, sb, ct) => factory(mk, options, sb, ct)));
+	}
+
+	/// <summary>
+	/// Unregisters a set of services with the global broker. This is separate from unproffering a service. A service should be unregistered before it is unproffered.
+	/// An <see cref="IServiceBroker.AvailabilityChanged"/> event is never
+	/// fired as a result of calling this method, but instead will be fired once the service is unproffered. To unproffer a service, simply dispose of it's proffering source.
+	/// </summary>
+	/// <param name="services">The set of services to be unregistered.</param>
+	protected void UnregisterServices(IEnumerable<ServiceMoniker> services)
+	{
+		lock (this.syncObject)
+		{
+			this.registeredServices = this.registeredServices.RemoveRange(services);
+		}
+	}
+
+	/// <summary>
+	/// Gets a <see cref="TraceSource"/> to apply to some brokered service.
+	/// </summary>
+	/// <param name="serviceBroker">A service broker that may be used to create the <see cref="TraceSource"/>.</param>
+	/// <param name="serviceMoniker">The moniker of the service being requested.</param>
+	/// <param name="options">The activation options accompanying the request.</param>
+	/// <param name="clientRole"><see langword="true"/> if the <see cref="TraceSource"/> will be used by the client of the service; <see langword="false"/> if used by the service itself.</param>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>A <see cref="TraceSource"/> instance that has the appropriate verbosity and listeners preconfigured, or <see langword="null" /> if the host provides no instance.</returns>
+	/// <remarks>
+	/// This method should be called by <see cref="IServiceBroker"/> implementations when requesting or activating services.
+	/// The result of this method should be passed to <see cref="ServiceRpcDescriptor.WithTraceSource(TraceSource?)"/> before constructing the RPC connection.
+	/// </remarks>
+	protected virtual ValueTask<TraceSource?> GetTraceSourceForConnectionAsync(IServiceBroker serviceBroker, ServiceMoniker serviceMoniker, ServiceActivationOptions options, bool clientRole, CancellationToken cancellationToken) => default;
+
+	/// <summary>
+	/// Indexes a proffered service factory or broker for fast lookup.
+	/// </summary>
+	/// <param name="proffered">The proffering wrapper.</param>
+	/// <returns>A value that may be disposed to cancel the proffer and remove its services from the index.</returns>
+	protected virtual IDisposable Proffer(IProffered proffered)
+	{
+		ImmutableDictionary<ServiceSource, ImmutableDictionary<ServiceMoniker, IProffered>> oldIndex;
+		lock (this.syncObject)
+		{
+			oldIndex = this.profferedServiceIndex;
+
+			if (proffered.Source > ServiceSource.OtherProcessOnSameMachine)
+			{
+				this.remoteSources = this.remoteSources.Add(proffered.Source, proffered);
+			}
+
+			if (!this.profferedServiceIndex.TryGetValue(proffered.Source, out ImmutableDictionary<ServiceMoniker, IProffered>? monikerAndProffer))
+			{
+				monikerAndProffer = ImmutableDictionary<ServiceMoniker, IProffered>.Empty;
+			}
+
+			// Index each service, and also validate that all proffered services are registered.
+			var monikerAndProfferBuilder = monikerAndProffer.ToBuilder();
+			ImmutableHashSet<ServiceMoniker> unregisteredMonikers = ImmutableHashSet<ServiceMoniker>.Empty;
+			foreach (ServiceMoniker moniker in proffered.Monikers)
+			{
+				if (!this.registeredServices.ContainsKey(moniker))
+				{
+					unregisteredMonikers = unregisteredMonikers.Add(moniker);
+				}
+
+				if (monikerAndProfferBuilder.ContainsKey(moniker))
+				{
+					// Only load the resources assembly when we know we're in the failure case.
+					Verify.FailOperation(Strings.ServiceMoniker_AlreadyProffered, moniker);
+				}
+
+				monikerAndProfferBuilder.Add(moniker, proffered);
+			}
+
+			Verify.Operation(unregisteredMonikers.IsEmpty, "Cannot proffer unregistered service(s): {0}", string.Join(", ", unregisteredMonikers));
+			this.profferedServiceIndex = this.profferedServiceIndex.SetItem(proffered.Source, monikerAndProfferBuilder.ToImmutable());
+		}
+
+		if (this.traceSource.Switch.ShouldTrace(TraceEventType.Information))
+		{
+			this.traceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.Proffered, "{0} proffered brokered service(s): {1}.", proffered.Source, ServiceBrokerUtilities.DeferredFormatting(() => string.Join(", ", proffered.Monikers)));
+		}
+
+		this.OnAvailabilityChanged(oldIndex, proffered);
+
+		return proffered;
+	}
+
+	/// <summary>
+	/// When overridden by a derived class, provides a hook to raise events, post telemetry, or log how each brokered service request was handled.
+	/// </summary>
+	/// <param name="moniker">The moniker for the requested service.</param>
+	/// <param name="descriptor">The descriptor associated with the request, if available.</param>
+	/// <param name="type">The nature of the brokered service request.</param>
+	/// <param name="result">An indicator as to how the brokered service request was handled.</param>
+	/// <param name="proffered">The proffering source that was used when activating the service.</param>
+	protected virtual void OnRequestHandled(ServiceMoniker moniker, ServiceRpcDescriptor? descriptor, RequestType type, RequestResult result, IProffered? proffered)
+	{
+	}
+
+	private static ServiceAudience ConvertRemoteSourceToLocalAudience(ServiceSource source)
+	{
+		return source switch
+		{
+			ServiceSource.OtherProcessOnSameMachine => ServiceAudience.Local,
+			ServiceSource.TrustedExclusiveServer => ServiceAudience.RemoteExclusiveClient,
+			ServiceSource.TrustedExclusiveClient => ServiceAudience.RemoteExclusiveServer,
+			ServiceSource.TrustedServer => ServiceAudience.LiveShareGuest,
+			ServiceSource.UntrustedServer => ServiceAudience.LiveShareGuest,
+			_ => throw new NotSupportedException(),
+		};
+	}
+
+	/// <summary>
+	/// Gets a value indicating whether a given service audience represents a local consumer (vs. a remote one).
+	/// </summary>
+	/// <param name="filter">The filter in effect on the <see cref="IServiceBroker"/>.</param>
+	/// <returns><see langword="true"/> if the filter represents a local consumer; <see langword="false"/> if a remote one.</returns>
+	private static bool IsLocalConsumer(ServiceAudience filter) => (filter & ~ServiceAudience.Local) == ServiceAudience.None;
+
+	/// <summary>
+	/// Gets a JSON object that describes the current state of the container, including all registered services, proffer services, brokers, connections, etc.
+	/// </summary>
+	/// <param name="serviceAudience">Specifies what perspective of the container should be used for data that indicates whether a service is available.</param>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>A JSON object.</returns>
+	/// <remarks>
+	/// The contents of this JSON blob are meant for human diagnostic purposes and are subject to change.
+	/// </remarks>
+	private async Task<JObject> GetDiagnosticsAsync(ServiceAudience serviceAudience, CancellationToken cancellationToken = default)
+	{
+		var json = new JObject();
+
+		IServiceBroker serviceBroker = this.GetFullAccessServiceBroker();
+		var remoteServices = new HashSet<ServiceMoniker>();
+		IBrokeredServiceManifest? manifest = await serviceBroker.GetProxyAsync<IBrokeredServiceManifest>(FrameworkServices.RemoteBrokeredServiceManifest, cancellationToken).ConfigureAwait(false);
+		try
+		{
+			if (manifest != null)
+			{
+				remoteServices.UnionWith(await manifest.GetAvailableServicesAsync(cancellationToken).ConfigureAwait(false));
+			}
+		}
+		finally
+		{
+			(manifest as IDisposable)?.Dispose();
+		}
+
+		json["perspectiveAudience"] = serviceAudience.ToString();
+		json["activeRemoteSources"] = new JArray(this.remoteSources.Keys.Select(s => s.ToString()));
+		json["localServicesBlockedDueToExclusiveClient"] = this.isClientOfExclusiveServer;
+		json["brokeredServices"] = new JArray(
+			from serviceRegistration in this.registeredServices
+			select new JObject(
+				new JProperty("name", serviceRegistration.Key.Name),
+				new JProperty("version", serviceRegistration.Key.Version?.ToString()),
+				new JProperty("audience", serviceRegistration.Value.Audience.ToString()),
+				new JProperty("allowGuestClients", serviceRegistration.Value.AllowGuestClients),
+				new JProperty("profferingPackage", serviceRegistration.Value.ProfferingPackageId),
+				new JProperty("profferedLocally", IsProfferedLocally(serviceRegistration.Key)),
+				new JProperty("activeSource", GetActiveSource(serviceRegistration.Key)?.ToString()),
+				new JProperty("localSourceBlockedByExclusiveClient", this.IsLocalProfferedServiceBlockedOnExclusiveClient(serviceRegistration.Value, serviceAudience)),
+				new JProperty("includedByRemoteSourceManifest", remoteServices?.Contains(serviceRegistration.Key))));
+
+		return json;
+
+		bool IsProfferedLocally(ServiceMoniker serviceMoniker)
+		{
+			return (this.profferedServiceIndex.TryGetValue(ServiceSource.SameProcess, out ImmutableDictionary<ServiceMoniker, IProffered>? proffers) && proffers.ContainsKey(serviceMoniker))
+				|| (this.profferedServiceIndex.TryGetValue(ServiceSource.OtherProcessOnSameMachine, out proffers) && proffers.ContainsKey(serviceMoniker));
+		}
+
+		ServiceSource? GetActiveSource(ServiceMoniker serviceMoniker)
+		{
+			if (this.TryGetProfferingSource(serviceMoniker, serviceAudience, out IProffered? proffered, out _))
+			{
+				return proffered.Source;
+			}
+
+			return null;
+		}
+	}
+
+	/// <summary>
+	/// Filters the registered service monikers to those that should be visible to our process from a given <paramref name="source"/>,
+	/// then optionally intersects that set with another set.
+	/// </summary>
+	/// <param name="source">The source of services that we should filter our registered list of services to.</param>
+	/// <param name="serviceMonikers">The set of monikers to optionally intersect the filtered registered services with.</param>
+	/// <returns>The filtered, intersected set of monikers.</returns>
+	private ImmutableHashSet<ServiceMoniker> GetAllowedMonikers(ServiceSource source, ImmutableHashSet<ServiceMoniker>? serviceMonikers)
+	{
+		// Determine what service audience would be required on any service registration
+		// in order for us to be willing to consume the proffered service, considering our position
+		// relative to the service source.
+		// For example if the services are coming from a Codespace Server,
+		// then we would only consume services from it that we know are exposed to a Codespace Client.
+		ServiceAudience ourAudienceRelativeToSource = ConvertRemoteSourceToLocalAudience(source);
+
+		// We need to look up the monikers for all the services that are allowed to come from this source.
+		ImmutableHashSet<ServiceMoniker>.Builder allowedMonikers = ImmutableHashSet.CreateBuilder<ServiceMoniker>();
+		foreach ((ServiceMoniker moniker, ServiceRegistration registration) in this.registeredServices)
+		{
+			// We consider the service consumable from the remote if and only if
+			// we would expose it over the same kind of connection if we were on the proffering side.
+			// When "remote" is just another process on this same machine (e.g. ServiceHub),
+			// we index the service even if this process can't consume it so we can expose it remotely.
+			// TryGetProfferingSource will prevent *this* process from consuming when Local isn't an audience.
+			if ((registration.Audience & ourAudienceRelativeToSource) == ourAudienceRelativeToSource || source == ServiceSource.OtherProcessOnSameMachine)
+			{
+				if (serviceMonikers == null || serviceMonikers.Contains(moniker))
+				{
+					allowedMonikers.Add(moniker);
+				}
+			}
+		}
+
+		return allowedMonikers.ToImmutable();
+	}
+
+	private bool IsPackageLoaded(object packageId)
+	{
+		lock (this.loadedPackageIds)
+		{
+			return this.loadedPackageIds.Contains(packageId);
+		}
+	}
+
+	private void RecordPackageLoaded(object packageId)
+	{
+		lock (this.loadedPackageIds)
+		{
+			this.loadedPackageIds.Add(packageId);
+		}
+	}
+
+	/// <summary>
+	/// Removes proffered services from the index.
+	/// </summary>
+	/// <param name="proffered">The proffered element to remove.</param>
+	private void RemoveRegistrations(IProffered proffered)
+	{
+		Requires.NotNull(proffered, nameof(proffered));
+
+		ImmutableDictionary<ServiceSource, ImmutableDictionary<ServiceMoniker, IProffered>> oldIndex;
+		lock (this.syncObject)
+		{
+			oldIndex = this.profferedServiceIndex;
+
+			switch (proffered.Source)
+			{
+				case ServiceSource.SameProcess:
+				case ServiceSource.OtherProcessOnSameMachine:
+					if (this.profferedServiceIndex.TryGetValue(proffered.Source, out ImmutableDictionary<ServiceMoniker, IProffered>? profferedServices))
+					{
+						profferedServices = profferedServices.RemoveRange(proffered.Monikers);
+						this.profferedServiceIndex = this.profferedServiceIndex.SetItem(proffered.Source, profferedServices);
+					}
+
+					break;
+				default:
+					// Non-local sources are only allowed to proffer one thing, so remove that.
+					this.profferedServiceIndex = this.profferedServiceIndex.Remove(proffered.Source);
+					this.remoteSources = this.remoteSources.Remove(proffered.Source);
+					break;
+			}
+		}
+
+		if (this.traceSource.Switch.ShouldTrace(TraceEventType.Information))
+		{
+			this.traceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.Proffered, "Brokered service(s) UNproffered from {0}: {1}.", proffered.Source, ServiceBrokerUtilities.DeferredFormatting(() => string.Join(", ", proffered.Monikers)));
+		}
+
+		this.OnAvailabilityChanged(oldIndex, proffered);
+	}
+
+	/// <summary>
+	/// Instructs each applicable <see cref="View"/> to raise its <see cref="IServiceBroker.AvailabilityChanged"/> event.
+	/// </summary>
+	/// <param name="oldIndex">The index of available services before the change. Null if no proffered index was changed, but an underlying service broker says a change was made.</param>
+	/// <param name="proffered">The service proffering entity that has changed the set of services available to us.</param>
+	/// <param name="impactedServices">A subset of services that are impacted by the change. If null, all services associated with the proffering party are impacted.</param>
+	private void OnAvailabilityChanged(ImmutableDictionary<ServiceSource, ImmutableDictionary<ServiceMoniker, IProffered>>? oldIndex, IProffered proffered, IImmutableSet<ServiceMoniker>? impactedServices = null)
+	{
+		Requires.NotNull(proffered, nameof(proffered));
+		Assumes.False(Monitor.IsEntered(this.syncObject)); // We should not hold a private lock while invoking event handlers.
+
+		EventHandler<(ImmutableDictionary<ServiceSource, ImmutableDictionary<ServiceMoniker, IProffered>>?, ImmutableHashSet<ServiceMoniker>)>? availabilityChanged = this.AvailabilityChanged;
+		if (availabilityChanged is null)
+		{
+			return;
+		}
+
+		// We must Intersect using a hash-based collection. Newtonsoft.Json tends to create ImmutableSortedSet<T> when deserializing
+		// an IImmutableSet<T>, which causes Intersect of a (non-comparable) ServiceMoniker type.
+		ImmutableHashSet<ServiceMoniker> intersectedServices = impactedServices != null ? proffered.Monikers.Intersect(impactedServices) : proffered.Monikers;
+
+		// Raise the event asynchronously so as to not block the caller that triggered this change.
+		// Some handlers are more expensive than others, and as we make no guarantee as to the thread this event is raised on,
+		// it should never be raised on the main thread.
+		// If handlers end up malfunctioning due to concurrent events, or if some handlers are so slow that they slow down others,
+		// we could have one ReentrantSemaphore per subscriber and thus ensure each subscriber never is invoked concurrently, nor can slow down other handlers.
+		if (this.joinableTaskFactory is not null)
+		{
+			_ = this.joinableTaskFactory.RunAsync(RaiseEventOnThreadpoolAsync);
+		}
+		else
+		{
+			RaiseEventOnThreadpoolAsync().Forget();
+		}
+
+		async Task RaiseEventOnThreadpoolAsync()
+		{
+			await TaskScheduler.Default.SwitchTo(alwaysYield: true);
+			try
+			{
+				availabilityChanged?.Invoke(this, (oldIndex, intersectedServices));
+			}
+			catch (Exception ex)
+			{
+				this.traceSource.TraceData(TraceEventType.Error, (int)TraceEvents.EventHandlerFaulted, $"An exception occurred while raising the {nameof(this.AvailabilityChanged)} event: {0}", ex);
+			}
+		}
+	}
+
+	/// <summary>
+	/// Gets the proffering broker for a given service, taking both remote and local services into account.
+	/// </summary>
+	/// <param name="serviceMoniker">The sought service.</param>
+	/// <param name="consumingAudience">The audience filter that applies to the <see cref="IServiceBroker"/> that has received the request.</param>
+	/// <param name="proffered">Receives the proffering wrapper if the service was found and exposed to the <paramref name="consumingAudience"/>.</param>
+	/// <param name="errorCode">Receives the error code that describes why we failed to get a proffering source for the service, if applicable.</param>
+	/// <returns><see langword="true"/> if the service broker wrapper was found; <see langword="false"/> otherwise.</returns>
+	private bool TryGetProfferingSource(ServiceMoniker serviceMoniker, ServiceAudience consumingAudience, [NotNullWhen(true)] out IProffered? proffered, out MissingBrokeredServiceErrorCode errorCode)
+	{
+		return this.TryGetProfferingSource(this.profferedServiceIndex, serviceMoniker, consumingAudience, out proffered, out errorCode);
+	}
+
+	/// <summary>
+	/// Gets the proffering broker for a given service, taking both remote and local services into account.
+	/// </summary>
+	/// <param name="profferedServiceIndex">The index to search for the proffering party.</param>
+	/// <param name="serviceMoniker">The sought service.</param>
+	/// <param name="consumingAudience">The audience filter that applies to the <see cref="IServiceBroker"/> that has received the request.</param>
+	/// <param name="proffered">Receives the proffering wrapper if the service was found and exposed to the <paramref name="consumingAudience"/>.</param>
+	/// <param name="errorCode">Receives the error code that describes why we failed to get a proffering source for the service, if applicable.</param>
+	/// <returns><see langword="true"/> if the service broker wrapper was found; <see langword="false"/> otherwise.</returns>
+	private bool TryGetProfferingSource(ImmutableDictionary<ServiceSource, ImmutableDictionary<ServiceMoniker, IProffered>> profferedServiceIndex, ServiceMoniker serviceMoniker, ServiceAudience consumingAudience, [NotNullWhen(true)] out IProffered? proffered, out MissingBrokeredServiceErrorCode errorCode)
+	{
+		ChaosBrokeredServiceAvailability availability =
+			this.chaosMonkeyConfiguration?.BrokeredServices is { } chaos && chaos.TryGetValue(serviceMoniker, out ChaosBrokeredService? chaosConfig)
+			? chaosConfig.Availability : ChaosBrokeredServiceAvailability.AllowAll;
+
+		if (this.TryLookupServiceRegistration(serviceMoniker, out ServiceRegistration? serviceRegistration, out ServiceMoniker? matchingServiceMoniker))
+		{
+			// If the consumer is local, we're willing to provide services to them from remote sources.
+			// Specifically: We don't provide remote consumers with remote services.
+			// We do NOT check whether the consuming (local) audience should have visibility into the remotely acquired services
+			// because the audience check was performed and services filtered when the remote service broker was originally proffered.
+			bool anyRemoteSourceExists = false;
+			if (IsLocalConsumer(consumingAudience))
+			{
+				foreach (ServiceSource source in PreferredSourceOrderForRemoteServices)
+				{
+					if (profferedServiceIndex.TryGetValue(source, out ImmutableDictionary<ServiceMoniker, IProffered>? proffersFromSource))
+					{
+						anyRemoteSourceExists = true;
+						if (proffersFromSource.TryGetValue(matchingServiceMoniker, out proffered))
+						{
+							if (availability != ChaosBrokeredServiceAvailability.AllowAll)
+							{
+								if (this.traceSource.Switch.ShouldTrace(TraceEventType.Warning))
+								{
+									this.traceSource.TraceEvent(TraceEventType.Warning, (int)TraceEvents.Request, "Request for \"{0}\" denied for remote request because of chaos configuration.", serviceMoniker);
+								}
+
+								errorCode = MissingBrokeredServiceErrorCode.ChaosConfigurationDeniedRequest;
+								return false;
+							}
+
+							if (this.traceSource.Switch.ShouldTrace(TraceEventType.Information))
+							{
+								this.traceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.Request, "Request for \"{0}\" will be fulfilled by {1}", serviceMoniker, proffered.Source);
+							}
+
+							errorCode = MissingBrokeredServiceErrorCode.NoExplanation;
+							return true;
+						}
+					}
+				}
+			}
+
+			// For locally proffered services, we first check that the consuming audience is allowed to see it.
+			// We only reach this far if the requested service was not expected to come from a remote source that we checked above.
+			if (serviceRegistration.IsExposedTo(consumingAudience))
+			{
+				if (this.IsLocalProfferedServiceBlockedOnExclusiveClient(serviceRegistration, consumingAudience) ||
+					(anyRemoteSourceExists && serviceRegistration.IsExposedLocally && serviceRegistration.IsExposedRemotely))
+				{
+					// We are connected to some remote host (or expect to be soon), and this service is designed to come from at least one kind of remote host.
+					// We therefore block the service from being accessed because we don't want a locally proffered service in this case.
+					errorCode = MissingBrokeredServiceErrorCode.LocalServiceHiddenOnRemoteClient;
+					proffered = default;
+					return false;
+				}
+
+				foreach (ServiceSource source in PreferredSourceOrderForLocalServices)
+				{
+					if (profferedServiceIndex.TryGetValue(source, out ImmutableDictionary<ServiceMoniker, IProffered>? proffersFromSource))
+					{
+						if (proffersFromSource.TryGetValue(matchingServiceMoniker, out proffered))
+						{
+							if (availability == ChaosBrokeredServiceAvailability.DenyAll)
+							{
+								if (this.traceSource.Switch.ShouldTrace(TraceEventType.Warning))
+								{
+									this.traceSource.TraceEvent(TraceEventType.Warning, (int)TraceEvents.Request, $"Request for {serviceMoniker} denied because of chaos configuration.");
+								}
+
+								errorCode = MissingBrokeredServiceErrorCode.ChaosConfigurationDeniedRequest;
+								return false;
+							}
+
+							if (this.traceSource.Switch.ShouldTrace(TraceEventType.Information))
+							{
+								this.traceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.Request, "Request for \"{0}\" will be fulfilled by {1}", serviceMoniker, proffered.Source);
+							}
+
+							errorCode = MissingBrokeredServiceErrorCode.NoExplanation;
+							return true;
+						}
+					}
+				}
+
+				errorCode = MissingBrokeredServiceErrorCode.ServiceFactoryNotProffered;
+			}
+			else
+			{
+				if (this.traceSource.Switch.ShouldTrace(TraceEventType.Warning))
+				{
+					this.traceSource.TraceEvent(TraceEventType.Warning, (int)TraceEvents.Request, "Request for \"{0}\" from {1} denied because the service is only exposed {2}.", serviceMoniker, consumingAudience, serviceRegistration.Audience);
+				}
+
+				errorCode = MissingBrokeredServiceErrorCode.ServiceAudienceMismatch;
+			}
+		}
+		else
+		{
+			errorCode = MissingBrokeredServiceErrorCode.NotLocallyRegistered;
+		}
+
+		proffered = default;
+		return false;
+	}
+
+	/// <summary>
+	/// Checks whether the given service should be denied from a local source on the basis that it should always come from a Codespace Server.
+	/// </summary>
+	/// <param name="serviceRegistration">The service that might be denied.</param>
+	/// <param name="consumingAudience">The consuming audience.</param>
+	/// <returns><see langword="true"/> if the locally proffered service should *not* be activated; <see langword="false"/> otherwise.</returns>
+	private bool IsLocalProfferedServiceBlockedOnExclusiveClient(ServiceRegistration serviceRegistration, ServiceAudience consumingAudience) =>
+		this.isClientOfExclusiveServer && IsLocalConsumer(consumingAudience) && serviceRegistration.IsExposedTo(ServiceAudience.RemoteExclusiveClient);
+
+	/// <summary>
+	/// Checks the in-memory index of registered services for the registration of a named service.
+	/// </summary>
+	/// <param name="serviceMoniker">The moniker for the service. If this includes a version, and no registration for that version exists, a registration without a version may be matched.</param>
+	/// <param name="serviceRegistration">The discovered service registration, if any.</param>
+	/// <param name="matchingServiceMoniker">The <paramref name="serviceMoniker"/> if a match was found, or a copy with the version removed if only a version-less service was registered, or <see langword="null"/>.</param>
+	/// <returns><see langword="true"/> if registration was found for the given <paramref name="serviceMoniker"/>; <see langword="false"/> otherwise.</returns>
+	private bool TryLookupServiceRegistration(ServiceMoniker serviceMoniker, [NotNullWhen(true)] out ServiceRegistration? serviceRegistration, [NotNullWhen(true)] out ServiceMoniker? matchingServiceMoniker)
+	{
+		// Take a snapshot of the registeredServices in case it changes in the middle of this method.
+		ImmutableDictionary<ServiceMoniker, ServiceRegistration> services = this.registeredServices;
+
+		// Try looking up the service registration, first by exact match and second without the version.
+		if (services.TryGetValue(serviceMoniker, out serviceRegistration))
+		{
+			matchingServiceMoniker = serviceMoniker;
+			return true;
+		}
+
+		if (serviceMoniker.Version is not null)
+		{
+			var versionlessMoniker = new ServiceMoniker(serviceMoniker.Name);
+			return this.TryLookupServiceRegistration(versionlessMoniker, out serviceRegistration, out matchingServiceMoniker);
+		}
+
+		matchingServiceMoniker = null;
+		return false;
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/IBrokeredServiceContainer.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/IBrokeredServiceContainer.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.ServiceHub.Framework;
+
+namespace Microsoft.VisualStudio.Shell.ServiceBroker;
+
+/// <summary>
+/// Provides a means to proffer services into <see cref="IServiceBroker"/> and access to the global <see cref="IServiceBroker"/>.
+/// </summary>
+public interface IBrokeredServiceContainer
+{
+	/// <summary>
+	/// Proffers a service for publication via an <see cref="IServiceBroker"/> associated with this container.
+	/// </summary>
+	/// <param name="serviceDescriptor">
+	/// The descriptor for the service.
+	/// The <see cref="ServiceRpcDescriptor.Moniker"/> is used to match service requests to the <paramref name="factory"/>.
+	/// The <see cref="ServiceRpcDescriptor.ConstructRpcConnection(System.IO.Pipelines.IDuplexPipe)"/> method is used to convert the service returned by the <paramref name="factory"/> to a pipe when the client prefers that.
+	/// </param>
+	/// <param name="factory">The delegate that will create new instances of the service for each client.</param>
+	/// <returns>A value that can be disposed to remove the proffered service from availability.</returns>
+	/// <exception cref="InvalidOperationException">
+	/// Thrown if <paramref name="serviceDescriptor"/> represents a <see cref="ServiceMoniker"/> that has already been proffered.
+	/// </exception>
+	/// <exception cref="ArgumentException">
+	/// Thrown if no registration can be found for the proffered <see cref="ServiceRpcDescriptor.Moniker"/>.
+	/// </exception>
+	/// <remarks>
+	/// The service identified by the <see cref="ServiceRpcDescriptor.Moniker"/> must have been pre-registered
+	/// with a <see cref="ServiceAudience"/> indicating who should have access to it and whether it might be obtained from a remote machine or user.
+	/// </remarks>
+	IDisposable Proffer(ServiceRpcDescriptor serviceDescriptor, BrokeredServiceFactory factory);
+
+	/// <inheritdoc cref="Proffer(ServiceRpcDescriptor, BrokeredServiceFactory)"/>
+	IDisposable Proffer(ServiceRpcDescriptor serviceDescriptor, AuthorizingBrokeredServiceFactory factory);
+
+	/// <summary>
+	/// Gets an <see cref="IServiceBroker"/> with full access to all services available to this process with local credentials applied by default for all service requests.
+	/// This should *not* be used within a brokered service, which should instead use the <see cref="IServiceBroker"/> that is given to its service factory.
+	/// </summary>
+	/// <returns>An <see cref="IServiceBroker"/> instance created for the caller.</returns>
+	/// <remarks>
+	/// <para>
+	/// When a service request is made with an empty set of <see cref="ServiceActivationOptions.ClientCredentials"/>,
+	/// local (full) permissions are applied.
+	/// A service request that includes its own client credentials may effectively "reduce" permission levels for the requested service
+	/// if the service contains authorization checks. It will not remove a service from availability entirely since the service audience
+	/// is always to allow all services to be obtained.
+	/// </para>
+	/// <para>
+	/// Callers should use the <see cref="IServiceBroker"/> they are provided via their <see cref="BrokeredServiceFactory"/> instead of using
+	/// this method to get an <see cref="IServiceBroker"/> so that they are secure by default.
+	/// An exception to this rule is when a service exposed to untrusted users has fully vetted the input for a specific incoming RPC call
+	/// and wishes to request other services with full trust in order to accomplish something the user would otherwise not have permission to do.
+	/// This should be done with great care.
+	/// </para>
+	/// </remarks>
+	IServiceBroker GetFullAccessServiceBroker();
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/IBrokeredServiceContainerDiagnostics.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/IBrokeredServiceContainerDiagnostics.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Shell.ServiceBroker;
+
+/// <summary>
+/// Allows for retrieval or export of manifest, registration and runtime data that can be useful in diagnosing a service acquisition failure.
+/// </summary>
+public interface IBrokeredServiceContainerDiagnostics
+{
+	/// <summary>
+	/// Writes a bunch of diagnostic data to a JSON file.
+	/// </summary>
+	/// <param name="filePath">The path to the JSON file to be written. If it already exists it will be overwritten.</param>
+	/// <param name="serviceAudience">The audience to consider is querying for services.</param>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>A task that completes when the writing is done.</returns>
+	Task ExportDiagnosticsAsync(string filePath, ServiceAudience serviceAudience, CancellationToken cancellationToken = default);
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/IBrokeredServiceContainerInternal.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/IBrokeredServiceContainerInternal.cs
@@ -1,0 +1,26 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.ServiceHub.Framework;
+
+namespace Microsoft.VisualStudio.Shell.ServiceBroker;
+
+/// <summary>
+/// An internal-interface that provides access to more of what <see cref="SVsBrokeredServiceContainer"/> offers.
+/// </summary>
+public interface IBrokeredServiceContainerInternal : IBrokeredServiceContainer
+{
+	/// <summary>
+	/// Gets credentials to use to impersonate the local user.
+	/// </summary>
+	IReadOnlyDictionary<string, string> LocalUserCredentials { get; }
+
+	/// <summary>
+	/// Gets a service broker that targets an out of proc and/or less trusted consumer.
+	/// </summary>
+	/// <param name="audience">The architectural position of the consumer.</param>
+	/// <param name="clientCredentials">The client credentials to associate with this consumer, if less trusted.</param>
+	/// <param name="credentialPolicy">How to apply client credentials to individual service requests.</param>
+	/// <returns>The custom <see cref="IServiceBroker"/>.</returns>
+	IServiceBroker GetLimitedAccessServiceBroker(ServiceAudience audience, IReadOnlyDictionary<string, string> clientCredentials, ClientCredentialsPolicy credentialPolicy);
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/IExportedBrokeredService.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/IExportedBrokeredService.cs
@@ -1,0 +1,40 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.ServiceHub.Framework;
+using StreamJsonRpc;
+
+namespace Microsoft.VisualStudio.Shell.ServiceBroker;
+
+/// <summary>
+/// An interface that must be implemented by a brokered service that is exported to MEF
+/// via the <see cref="ExportBrokeredServiceAttribute"/>.
+/// </summary>
+public interface IExportedBrokeredService
+{
+	/// <summary>
+	/// Gets the <see cref="ServiceRpcDescriptor"/> to be used when activating the service.
+	/// </summary>
+	/// <remarks>
+	/// When a brokered service supports multiple versions in their <see cref="ServiceMoniker"/>,
+	/// it may be important to consider the version being activated to know which <see cref="ServiceRpcDescriptor"/> to return
+	/// from this property.
+	/// This <see cref="ServiceMoniker"/> may be imported via MEF in the same MEF part that implements this interface
+	/// in order to check the value before returning from this property getter.
+	/// </remarks>
+	ServiceRpcDescriptor Descriptor { get; }
+
+	/// <summary>
+	/// Initializes the brokered service before returning the new instance to its client.
+	/// </summary>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>A task that completes with initialization.</returns>
+	/// <remarks>
+	/// <para>This method offers the brokered service an <em>optional</em> opportunity to do async initialization,
+	/// similar to what <see cref="BrokeredServiceFactory"/> would have allowed for when proffering a non-MEF
+	/// brokered service with <see cref="IBrokeredServiceContainer.Proffer(ServiceRpcDescriptor, BrokeredServiceFactory)"/>.
+	/// Empty methods may simply return <see cref="Task.CompletedTask"/>.</para>
+	/// </remarks>
+	[JsonRpcIgnore]
+	Task InitializeAsync(CancellationToken cancellationToken);
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/IMissingServiceDiagnosticsService.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/IMissingServiceDiagnosticsService.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.ServiceHub.Framework;
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+/// <summary>
+/// Provides diagnostics to understand why brokered services are not activatable.
+/// </summary>
+public interface IMissingServiceDiagnosticsService
+{
+	/// <summary>
+	/// Analyzes possible explanations for why a brokered service could not be acquired.
+	/// </summary>
+	/// <param name="missingServiceMoniker">The moniker of the missing brokered service.</param>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>An analysis describing the first problem encountered while looking for the brokered service.</returns>
+	Task<MissingServiceAnalysis> AnalyzeMissingServiceAsync(ServiceMoniker missingServiceMoniker, CancellationToken cancellationToken);
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/MissingBrokeredServiceErrorCode.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/MissingBrokeredServiceErrorCode.cs
@@ -1,0 +1,63 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+/// <summary>
+/// Defines the several reasons a brokered service might not be obtained.
+/// </summary>
+public enum MissingBrokeredServiceErrorCode
+{
+	/// <summary>
+	/// Nothing could be found wrong to explain the missing service.
+	/// It may be available now.
+	/// </summary>
+	NoExplanation,
+
+	/// <summary>
+	/// The requested service had no match in the local service registry.
+	/// </summary>
+	/// <remarks>
+	/// All services, whether local or remote, must be in the local registry in order to be acquired locally.
+	/// </remarks>
+	NotLocallyRegistered,
+
+	/// <summary>
+	/// Special resiliency testing configuration is in place and denied access to this service.
+	/// </summary>
+	ChaosConfigurationDeniedRequest,
+
+	/// <summary>
+	/// The service is expected to come from an exclusive server (e.g. a Codespace Server)
+	/// but the connection is not ready yet or the server does not offer it.
+	/// </summary>
+	[Obsolete("Use " + nameof(LocalServiceHiddenOnRemoteClient) + " instead.")]
+	LocalServiceHiddenOnExclusiveClient,
+
+	/// <summary>
+	/// The service is not exposed to the audience making the request.
+	/// </summary>
+	ServiceAudienceMismatch,
+
+	/// <summary>
+	/// The service is registered but no factory has been loaded for it.
+	/// </summary>
+	ServiceFactoryNotProffered,
+
+	/// <summary>
+	/// The service factory returned null instead of an instance of the service.
+	/// </summary>
+	ServiceFactoryReturnedNull,
+
+	/// <summary>
+	/// The service factory threw an exception.
+	/// </summary>
+	ServiceFactoryFault,
+
+	/// <summary>
+	/// The service is expected to come from a remote server
+	/// but the connection is not ready yet or the server does not offer it.
+	/// A locally proffered service is not available when it also can come remotely and a remote connection exists or is expected.
+	/// </summary>
+	LocalServiceHiddenOnRemoteClient,
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/MissingServiceAnalysis.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/MissingServiceAnalysis.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.ServiceHub.Framework;
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+/// <summary>
+/// Contains the result of a missing service analysis as returned from <see cref="IMissingServiceDiagnosticsService.AnalyzeMissingServiceAsync(ServiceMoniker, CancellationToken)"/>.
+/// </summary>
+public class MissingServiceAnalysis
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="MissingServiceAnalysis"/> class.
+	/// </summary>
+	/// <param name="errorCode">The error code explaining why the service could not be obtained.</param>
+	/// <param name="expectedSource">The source that the service was expected to come from.</param>
+	internal MissingServiceAnalysis(MissingBrokeredServiceErrorCode errorCode, ServiceSource? expectedSource)
+	{
+		this.ErrorCode = errorCode;
+		this.ExpectedSource = expectedSource;
+	}
+
+	/// <summary>
+	/// Gets the error code explaining why the service could not be obtained.
+	/// </summary>
+	public MissingBrokeredServiceErrorCode ErrorCode { get; }
+
+	/// <summary>
+	/// Gets the source that the service was expected to come from.
+	/// </summary>
+	public ServiceSource? ExpectedSource { get; }
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/RemoteServiceBrokerWrapper.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/RemoteServiceBrokerWrapper.cs
@@ -1,0 +1,150 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Diagnostics;
+using System.IO.Pipelines;
+using System.IO.Pipes;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.Win32.SafeHandles;
+using Nerdbank.Streams;
+using Windows.Win32;
+using IAsyncDisposable = System.IAsyncDisposable;
+using Task = System.Threading.Tasks.Task;
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+internal class RemoteServiceBrokerWrapper : IRemoteServiceBroker, IDisposable
+{
+	// Keep in sync with property in {DevCore repo}/src/clr/utiltity/Microsoft.ServiceHub.Utiltity.Shared/Constants.cs
+	private const string ServiceHubHostProcessIdActivationArgument = "__servicehub__HostProcessId";
+
+	private readonly IServiceBroker serviceBroker;
+	private ImmutableDictionary<Guid, IAsyncDisposable> remoteServiceRequests = ImmutableDictionary<Guid, IAsyncDisposable>.Empty;
+
+	public RemoteServiceBrokerWrapper(IServiceBroker serviceBroker)
+	{
+		Requires.NotNull(serviceBroker, nameof(serviceBroker));
+		this.serviceBroker = serviceBroker;
+		this.serviceBroker.AvailabilityChanged += this.OnAvailabilityChanged;
+	}
+
+	public event EventHandler<BrokeredServicesChangedEventArgs>? AvailabilityChanged;
+
+	/// <inheritdoc />
+	public Task HandshakeAsync(ServiceBrokerClientMetadata clientMetadata, CancellationToken cancellationToken = default)
+	{
+		if (!clientMetadata.SupportedConnections.HasFlag(RemoteServiceConnections.IpcPipe))
+		{
+			// Only support pipes.
+			throw new NotSupportedException();
+		}
+
+		return Task.CompletedTask;
+	}
+
+	/// <inheritdoc />
+	public Task<RemoteServiceConnectionInfo> RequestServiceChannelAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions serviceActivationOptions, CancellationToken cancellationToken = default)
+	{
+		return this.RequestServiceChannelAsync(
+			() => this.serviceBroker.GetPipeAsync(serviceMoniker, serviceActivationOptions, cancellationToken),
+			serviceMoniker,
+			serviceActivationOptions,
+			cancellationToken);
+	}
+
+	/// <inheritdoc />
+	public async Task CancelServiceRequestAsync(Guid serviceRequestId)
+	{
+		if (ImmutableInterlocked.TryRemove(ref this.remoteServiceRequests, serviceRequestId, out IAsyncDisposable? server))
+		{
+			await server.DisposeAsync().ConfigureAwait(false);
+		}
+	}
+
+	public void Dispose()
+	{
+		this.serviceBroker.AvailabilityChanged -= this.OnAvailabilityChanged;
+	}
+
+	internal Task<RemoteServiceConnectionInfo> RequestServiceChannelAsync(
+		Func<ValueTask<IDuplexPipe?>> getPipeAsyncDelegate,
+		ServiceMoniker serviceMoniker,
+		ServiceActivationOptions serviceActivationOptions,
+		CancellationToken cancellationToken)
+	{
+		var requestId = Guid.NewGuid();
+
+		if (serviceActivationOptions.ActivationArguments == null ||
+			!serviceActivationOptions.ActivationArguments.TryGetValue(ServiceHubHostProcessIdActivationArgument, out string? hostProcessidString) ||
+			!int.TryParse(hostProcessidString, out int activationOptionProcessId))
+		{
+			throw new InvalidOperationException(string.Format(Strings.Error_InvalidExternalClientProcessPid, nameof(ServiceActivationOptions), ServiceHubHostProcessIdActivationArgument));
+		}
+
+		IIpcServer server = ServerFactory.Create(
+			async (stream) =>
+			{
+#if NET5_0_OR_GREATER
+				if (OperatingSystem.IsWindowsVersionAtLeast(8))
+#else
+				if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+#endif
+				{
+					if (!(stream is PipeStream { SafePipeHandle: SafePipeHandle handle }))
+					{
+						throw new InvalidOperationException(Strings.NamedPipeClientCouldNotBeValidated);
+					}
+
+					if (!PInvoke.GetNamedPipeClientProcessId(handle, out uint clientProcessId))
+					{
+						throw new InvalidOperationException(Strings.CouldNotGetProcessId);
+					}
+
+					if (clientProcessId != activationOptionProcessId)
+					{
+						throw new InvalidOperationException(string.Format(Strings.FailedToValidateClient, serviceMoniker.ToString()));
+					}
+				}
+
+				// Cancelling the service request ends up disposing the server and removing it from the list of
+				// active requests which is exactly the behavior we want here.
+				// This task is run anonymously because a server cannot be disposed if it is inside
+				// its OnConnected callback so it will be result in a deadlock.
+				Task.Run(() => this.CancelServiceRequestAsync(requestId)).Forget();
+
+				IDuplexPipe? servicePipe = await getPipeAsyncDelegate().ConfigureAwait(false);
+
+				if (servicePipe != null)
+				{
+					IDuplexPipe serverPipe = stream.UsePipe();
+
+					// Link the two pipes so that all incoming/outgoing calls get forwarded
+					ServiceBrokerUtilities.LinkAsync(serverPipe.Input, servicePipe.Output, cancellationToken).Forget();
+					ServiceBrokerUtilities.LinkAsync(servicePipe.Input, serverPipe.Output, cancellationToken).Forget();
+				}
+				else
+				{
+					await stream.DisposeAsync().ConfigureAwait(false);
+				}
+			},
+			new ServerFactory.ServerOptions
+			{
+				TraceSource = new TraceSource($"{this.serviceBroker.GetType().Name}-{serviceMoniker.Name}"),
+			});
+
+		ImmutableInterlocked.TryAdd(ref this.remoteServiceRequests, requestId, server);
+
+		return Task.FromResult(new RemoteServiceConnectionInfo
+		{
+			RequestId = requestId,
+			PipeName = server.Name,
+		});
+	}
+
+	private void OnAvailabilityChanged(object? sender, BrokeredServicesChangedEventArgs args)
+	{
+		this.AvailabilityChanged?.Invoke(this, args);
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/SVsBrokeredServiceContainer.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/SVsBrokeredServiceContainer.cs
@@ -1,0 +1,16 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Runtime.InteropServices;
+
+namespace Microsoft.VisualStudio.Shell.ServiceBroker;
+
+#pragma warning disable SA1302 // Interface names should begin with I
+
+/// <summary>
+/// The service ID for the <see cref="IBrokeredServiceContainer">brokered service container</see>.
+/// </summary>
+[Guid("893F2DE0-EA58-49C1-ACBA-CE6B16236ABF")]
+public interface SVsBrokeredServiceContainer
+{
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/SVsFullAccessServiceBroker.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/SVsFullAccessServiceBroker.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.ServiceHub.Framework;
+
+namespace Microsoft.VisualStudio.Shell.ServiceBroker;
+
+#pragma warning disable SA1302 // Interface names should begin with I
+
+/// <summary>
+/// A type to serve as the MEF contract name for importing an <see cref="IServiceBroker"/> that is equivalent
+/// to what would have come from a call to <see cref="IBrokeredServiceContainer.GetFullAccessServiceBroker"/> on
+/// the <see cref="SVsBrokeredServiceContainer"/>.
+/// </summary>
+/// <remarks>
+/// This can be imported in a MEF part like this:
+/// <code><![CDATA[
+/// [Import(typeof(SVsFullAccessServiceBroker))]
+/// private IServiceBroker serviceBroker;
+/// ]]></code>
+/// </remarks>
+public interface SVsFullAccessServiceBroker
+{
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/ServiceAudience.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/ServiceAudience.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.ServiceHub.Framework;
+
+namespace Microsoft.VisualStudio.Shell.ServiceBroker;
+
+/// <summary>
+/// Identifies various audiences that may want or need to access a service.
+/// When used to register a service (e.g. ProvideBrokeredServiceAttribute)
+/// it determines whether that service can be accessed locally, remotely and/or by 3rd parties.
+/// </summary>
+/// <remarks>
+/// This enum may also be used as a filter when constructing an <see cref="IServiceBroker"/>
+/// where each flag reduces the set of services available as only services that specify every flag
+/// in the filter are available.
+/// </remarks>
+[Flags]
+public enum ServiceAudience
+{
+	/// <summary>
+	/// No flags. The service is not available to anyone.
+	/// When used for a filtered view, it means apply no filters (all services are available).
+	/// </summary>
+	None = 0x0,
+
+	/// <summary>
+	/// Services are available for clients running in the same process (or <see cref="AppDomain" /> on the .NET Framework).
+	/// They will not be available from other processes (e.g. ServiceHub services).
+	/// A brokered service that includes this flag may still be *indirectly* exposed to <see cref="LiveShareGuest"/>
+	/// by way of another brokered service that is exposed to <see cref="LiveShareGuest"/> that is proffered from this process.
+	/// </summary>
+	Process = 0x1,
+
+	/// <summary>
+	/// The service is available for clients that support this process (e.g. ServiceHub services). These always run on the same machine and user account.
+	/// It does *not* include processes connected over Live Share or a Visual Studio Online Environment connection, even if these processes are running on the same machine.
+	/// A brokered service that includes this flag may still be *indirectly* exposed to <see cref="LiveShareGuest"/>
+	/// by way of another brokered service that is exposed to <see cref="LiveShareGuest"/> that is proffered from this machine.
+	/// </summary>
+	Local = Process | 0x2,
+
+	/// <summary>
+	/// When the service is running on an Visual Studio Online environment it is available to the client.
+	/// </summary>
+	/// <remarks>
+	/// Host services are available for the *one* client running on any machine that is connected remotely using the exclusive
+	/// owner connection (not the traditional Live Share sharing session).
+	/// Such a connection is *always* owned by the same owner as the server and thus is considered trusted.
+	/// </remarks>
+	RemoteExclusiveClient = 0x100,
+
+	/// <summary>
+	/// When the service is running on a Live Share host it is available for Live Share guests,
+	/// which may or may not be using the same user account as the host.
+	/// </summary>
+	/// <remarks>
+	/// Host services are available for remote Live Share clients running under *any* user account.
+	/// Any necessary authorization checks are the responsibility of the service.
+	/// </remarks>
+	LiveShareGuest = 0x400,
+
+	/// <summary>
+	/// When the service is running on a client of an Visual Studio Online environment, it is available to the server.
+	/// </summary>
+	/// <remarks>
+	/// Client services are proffered to a server over an exclusive connection that is always operated by the owner at both ends
+	/// (and is not the traditional Live Share sharing session).
+	/// A server never has more than one of these connections concurrently.
+	/// </remarks>
+	RemoteExclusiveServer = 0x800,
+
+	/// <summary>
+	/// The service is available for local processes as well as clients of Visual Studio Online environments and all Live Share guests (including untrusted strangers).
+	/// </summary>
+	/// <remarks>
+	/// Host services are available for all clients (owner or guest), whether they are local, remote over Live Share or remote over an exclusive connection.
+	/// </remarks>
+	AllClientsIncludingGuests = Local | RemoteExclusiveClient | LiveShareGuest,
+
+	/// <summary>
+	/// The service is considered part of the public SDK,
+	/// and thus is available to 3rd party clients that are only privileged to access public SDK services.
+	/// This flag should only be specified for public services that have stable APIs.
+	/// This flag must be combined with other flags to indicate which local and/or remote clients are allowed to request this service.
+	/// </summary>
+	PublicSdk = 0x10000000,
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/ServiceBrokerForExportedBrokeredServices.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/ServiceBrokerForExportedBrokeredServices.cs
@@ -1,0 +1,189 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Composition;
+using System.IO.Pipelines;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.ServiceHub.Framework.Services;
+
+namespace Microsoft.VisualStudio.Shell.ServiceBroker;
+
+/// <summary>
+/// Provides an <see cref="IServiceBroker"/> implementation for brokered services proffered via MEF
+/// and serves as the factory for these services.
+/// </summary>
+/// <remarks>
+/// This factory only creates <em>one</em> brokered service.
+/// As this object serves as the entry into a MEF sharing boundary, that means only one brokered service gets an instance of this class.
+/// This is as desired, since each consumer of an <see cref="IServiceBroker"/> should ideally have its own copy.
+/// </remarks>
+[Export]
+[Export(typeof(IServiceBroker))]
+[Shared(ExportedBrokeredServiceSharingBoundary)]
+internal class ServiceBrokerForExportedBrokeredServices : IServiceBroker, IDisposable
+{
+	internal const string ExportedBrokeredServiceSharingBoundary = "Microsoft.VisualStudio.ExportedBrokeredServiceScope";
+
+	private readonly object syncObject = new();
+	private IServiceBroker? innerServiceBroker;
+	private EventHandler<BrokeredServicesChangedEventArgs>? availabilityChanged;
+
+	event EventHandler<BrokeredServicesChangedEventArgs>? IServiceBroker.AvailabilityChanged
+	{
+		add
+		{
+			lock (this.syncObject)
+			{
+				if (this.availabilityChanged is null && this.InnerServiceBroker is not null)
+				{
+					this.InnerServiceBroker.AvailabilityChanged += this.ServiceBroker_AvailabilityChanged;
+				}
+
+				this.availabilityChanged += value;
+			}
+		}
+
+		remove
+		{
+			lock (this.syncObject)
+			{
+				this.availabilityChanged -= value;
+
+				if (this.availabilityChanged is null && this.InnerServiceBroker is not null)
+				{
+					this.InnerServiceBroker.AvailabilityChanged -= this.ServiceBroker_AvailabilityChanged;
+				}
+			}
+		}
+	}
+
+	/// <summary>
+	/// Gets or sets the <see cref="IServiceBroker"/> that this instance forwards all calls to.
+	/// </summary>
+	/// <remarks>
+	/// This should be set early during MEF brokered service activation so that it can be imported by the brokered service once activated.
+	/// This should be set to an object that is scoped for the particular activated brokered service the same way the object passed to
+	/// <see cref="BrokeredServiceFactory"/> would be.
+	/// </remarks>
+	internal IServiceBroker? InnerServiceBroker
+	{
+		get => this.innerServiceBroker;
+		set
+		{
+			lock (this.syncObject)
+			{
+				Verify.Operation(this.innerServiceBroker is null, "Already set.");
+				this.innerServiceBroker = value;
+				if (this.innerServiceBroker is not null && this.availabilityChanged is not null)
+				{
+					this.innerServiceBroker.AvailabilityChanged += this.ServiceBroker_AvailabilityChanged;
+				}
+			}
+		}
+	}
+
+	/// <summary>
+	/// Gets or sets the <see cref="ServiceActivationOptions"/> for the particular brokered service this object in created to serve.
+	/// </summary>
+	/// <remarks>
+	/// This should be set early during MEF brokered service activation so that it can be imported by the brokered service once activated.
+	/// </remarks>
+	[Export]
+	internal ServiceActivationOptions ServiceActivationOptions { get; set; }
+
+	/// <summary>
+	/// Gets or sets the <see cref="ServiceMoniker"/> for the particular brokered service this object in created to serve.
+	/// </summary>
+	/// <remarks>
+	/// This should be set early during MEF brokered service activation so that it can be imported by the brokered service once activated.
+	/// </remarks>
+	[Export]
+	internal ServiceMoniker? ActivatedMoniker { get; set; }
+
+	/// <summary>
+	/// Gets or sets the <see cref="ServiceHub.Framework.Services.AuthorizationServiceClient"/> to be exported for optional use by the brokered service.
+	/// </summary>
+	[Export]
+	internal AuthorizationServiceClient? AuthorizationServiceClient { get; set; }
+
+	/// <summary>
+	/// Gets an enumerable of the metadata exported from all MEF-based brokered services.
+	/// </summary>
+	/// <remarks>
+	/// This is used for brokered service registration and proffering by the <see cref="ServiceBrokerOfExportedServices.Initialize"/> method.
+	/// </remarks>
+	internal IEnumerable<IBrokeredServicesExportMetadata> ExportedServiceMetadata => this.Helper.ExportedBrokeredServices.Select(e => e.Metadata);
+
+	/// <summary>
+	/// Gets or sets a helper class that contains MefV1 imports.
+	/// </summary>
+	[Import]
+	private MefV1Helper Helper { get; set; } = null!;
+
+	ValueTask<IDuplexPipe?> IServiceBroker.GetPipeAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions options, CancellationToken cancellationToken)
+	{
+		Assumes.Present(this.InnerServiceBroker);
+		return this.InnerServiceBroker.GetPipeAsync(serviceMoniker, options, cancellationToken);
+	}
+
+	ValueTask<T?> IServiceBroker.GetProxyAsync<T>(ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options, CancellationToken cancellationToken)
+		where T : class
+	{
+		Assumes.Present(this.InnerServiceBroker);
+		return this.InnerServiceBroker.GetProxyAsync<T>(serviceDescriptor, options, cancellationToken);
+	}
+
+	public void Dispose()
+	{
+		this.AuthorizationServiceClient?.Dispose();
+	}
+
+	/// <summary>
+	/// Activates the one brokered service indicated by the <see cref="ActivatedMoniker"/> property.
+	/// </summary>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>The activated service.</returns>
+	internal async ValueTask<IExportedBrokeredService?> CreateBrokeredServiceAsync(CancellationToken cancellationToken)
+	{
+		Verify.Operation(this.ActivatedMoniker is not null, "Exporting properties must be set first.");
+
+		string? requiredVersion = this.ActivatedMoniker.Version?.ToString();
+		foreach (Lazy<IExportedBrokeredService, IBrokeredServicesExportMetadata> factory in this.Helper.ExportedBrokeredServices)
+		{
+			for (int i = 0; i < factory.Metadata.ServiceName.Length; i++)
+			{
+				if (this.ActivatedMoniker.Name == factory.Metadata.ServiceName[i] && requiredVersion == factory.Metadata.ServiceVersion[i])
+				{
+					Verify.Operation(!factory.IsValueCreated, "This method should only be called once.");
+					await factory.Value.InitializeAsync(cancellationToken).ConfigureAwait(false);
+					return factory.Value;
+				}
+			}
+		}
+
+		return null;
+	}
+
+	private void ServiceBroker_AvailabilityChanged(object? sender, BrokeredServicesChangedEventArgs e) => this.availabilityChanged?.Invoke(this, e);
+
+	/// <summary>
+	/// A class with MEFv1 attributes to force brokered service NonShared construction.
+	/// </summary>
+	/// <remarks>
+	/// Our parent class must use MEFv2 attributes because only they can express sharing boundaries with <see cref="SharedAttribute"/>.
+	/// But only MEFv1 attributes allow setting <see cref="System.ComponentModel.Composition.ImportManyAttribute.RequiredCreationPolicy"/>
+	/// as required to activate a new brokered service for each client.
+	/// We bridge this feature gap between the two sets of attributes via this helper class, so that the outer class can use MEFv2
+	/// and the nested class can use MEFv1, thereby making both sets of features available as required.
+	/// </remarks>
+	[System.ComponentModel.Composition.Export]
+	[System.ComponentModel.Composition.PartCreationPolicy(System.ComponentModel.Composition.CreationPolicy.NonShared)]
+	private class MefV1Helper
+	{
+		/// <summary>
+		/// Gets or sets the collection of all brokered services, from which only one is ever activated (for a given instance of this class).
+		/// </summary>
+		[System.ComponentModel.Composition.ImportMany(RequiredCreationPolicy = System.ComponentModel.Composition.CreationPolicy.NonShared)]
+		internal List<Lazy<IExportedBrokeredService, IBrokeredServicesExportMetadata>> ExportedBrokeredServices { get; set; } = null!;
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/ServiceBrokerOfExportedServices.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/ServiceBrokerOfExportedServices.cs
@@ -1,0 +1,298 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.IO.Pipelines;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.ServiceHub.Framework.Services;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Utilities.ServiceBroker;
+using Nerdbank.Streams;
+
+namespace Microsoft.VisualStudio.Shell.ServiceBroker;
+
+/// <summary>
+/// Implements the <see cref="IServiceBroker"/> to be proffered into the <see cref="GlobalBrokeredServiceContainer"/>
+/// in order to effectively proffer all the MEF-activated brokered services in the IDE.
+/// </summary>
+/// <remarks>
+/// A host IDE should derive from this class and apply <see cref="ExportAttribute"/> to the derived type.
+/// At startup, the IDE should acquire this export and call <see cref="RegisterAndProfferServicesAsync(System.Threading.CancellationToken)"/>
+/// to add MEF exported brokered services to the container.
+/// </remarks>
+public abstract class ServiceBrokerOfExportedServices : IServiceBroker
+{
+	private static readonly ProtectedOperation ClientIsOwnerProtectedOperation = WellKnownProtectedOperations.CreateClientIsOwner();
+
+	/// <summary>
+	/// The registration data for all MEF brokered services.
+	/// </summary>
+	private ImmutableDictionary<ServiceMoniker, ServiceRegistration> serviceRegistration = ImmutableDictionary<ServiceMoniker, ServiceRegistration>.Empty;
+
+	/// <summary>
+	/// The monikers to all MEF brokered services.
+	/// </summary>
+	private ImmutableHashSet<ServiceMoniker> serviceMonikers = ImmutableHashSet<ServiceMoniker>.Empty;
+
+	/// <summary>
+	/// We never raise this event, so just drop the handlers on the floor.
+	/// </summary>
+	event EventHandler<BrokeredServicesChangedEventArgs>? IServiceBroker.AvailabilityChanged
+	{
+		add { }
+		remove { }
+	}
+
+	/// <summary>
+	/// Gets or sets the sharing boundary factory used to activate each MEF brokered service.
+	/// </summary>
+	[Import]
+	[SharingBoundary(ServiceBrokerForExportedBrokeredServices.ExportedBrokeredServiceSharingBoundary)]
+	private ExportFactory<ServiceBrokerForExportedBrokeredServices> ServiceBrokerFactory { get; set; } = null!;
+
+	/// <inheritdoc cref="RegisterAndProfferServices(GlobalBrokeredServiceContainer)"/>
+	public async Task RegisterAndProfferServicesAsync(CancellationToken cancellationToken)
+	{
+		GlobalBrokeredServiceContainer container = await this.GetBrokeredServiceContainerAsync(cancellationToken).ConfigureAwait(false);
+		this.RegisterAndProfferServices(container);
+	}
+
+	/// <summary>
+	/// Registers MEF exported brokered services and proffers a factory for them.
+	/// </summary>
+	/// <param name="container">The container to register and proffer the services with.</param>
+	public void RegisterAndProfferServices(GlobalBrokeredServiceContainer container)
+	{
+		this.Initialize();
+
+		container.RegisterServices(this.serviceRegistration);
+		container.Proffer(this, this.serviceMonikers);
+	}
+
+	async ValueTask<IDuplexPipe?> IServiceBroker.GetPipeAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions options, CancellationToken cancellationToken)
+	{
+		try
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			ServiceRpcDescriptor.RpcConnection? connection = null;
+			GlobalBrokeredServiceContainer container = await this.GetBrokeredServiceContainerAsync(cancellationToken).ConfigureAwait(false);
+			IServiceBroker contextualServiceBroker = container.GetSecureServiceBroker(options);
+
+			Export<ServiceBrokerForExportedBrokeredServices>? export = await this.ActivateBrokeredServiceAsync(serviceMoniker, contextualServiceBroker, options, cancellationToken).ConfigureAwait(false);
+			if (export is null)
+			{
+				return null;
+			}
+
+			IExportedBrokeredService? brokeredService = null;
+
+			try
+			{
+				brokeredService = await export.Value.CreateBrokeredServiceAsync(cancellationToken).ConfigureAwait(false);
+				if (brokeredService is null)
+				{
+					export.Dispose();
+					return null;
+				}
+
+				ServiceRpcDescriptor descriptor = brokeredService.Descriptor
+					.WithTraceSource(await container.GetTraceSourceForBrokeredServiceAsync(contextualServiceBroker, serviceMoniker, options, clientRole: false, cancellationToken).ConfigureAwait(false));
+
+				if (descriptor is ServiceJsonRpcDescriptor { MultiplexingStreamOptions: null } oldJsonRpcDescriptor)
+				{
+					// We encourage users to migrate to descriptors configured with ServiceJsonRpcDescriptor.WithMultiplexingStream(MultiplexingStream.Options).
+#pragma warning disable CS0618 // Type or member is obsolete, only for backward compatibility.
+					descriptor = oldJsonRpcDescriptor.WithMultiplexingStream(options.MultiplexingStream);
+#pragma warning restore CS0618 // Type or member is obsolete
+				}
+
+				(IDuplexPipe, IDuplexPipe) pipePair = FullDuplexStream.CreatePipePair();
+
+				using (options.ApplyCultureToCurrentContext())
+				{
+					connection = descriptor.ConstructRpcConnection(pipePair.Item1);
+
+					// If the service needs to be able to call back to the client, arrange for it.
+					// If the client is remote, we need to create an RPC proxy back to the client.
+					// If the client is local, it should provide itself as the RPC target. So we only provide one if the client hasn't already done so.
+					// FWIW: it would be pretty odd if (ClientRpcTarget != null) since they're asking for a pipe so presumably they are remote.
+					if (descriptor.ClientInterface is not null && options.ClientRpcTarget is null)
+					{
+						options.ClientRpcTarget = connection.ConstructRpcClient(descriptor.ClientInterface);
+					}
+
+					// Arrange for proxy disposal to also dispose of our export to avoid a MEF leak.
+					connection.Completion.ContinueWith((_, s) => ((IDisposable)s!).Dispose(), export, CancellationToken.None, TaskContinuationOptions.None, TaskScheduler.Default).Forget();
+
+					connection.AddLocalRpcTarget(brokeredService);
+					connection.StartListening();
+					return pipePair.Item2;
+				}
+			}
+			catch
+			{
+				(brokeredService as IDisposable)?.Dispose();
+				export.Dispose();
+				connection?.Dispose();
+				throw;
+			}
+		}
+		catch (Exception ex)
+		{
+			throw new ServiceActivationFailedException(serviceMoniker, ex);
+		}
+	}
+
+	async ValueTask<T?> IServiceBroker.GetProxyAsync<T>(ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options, CancellationToken cancellationToken)
+		where T : class
+	{
+		try
+		{
+			cancellationToken.ThrowIfCancellationRequested();
+			GlobalBrokeredServiceContainer container = await this.GetBrokeredServiceContainerAsync(cancellationToken).ConfigureAwait(false);
+			IServiceBroker contextualServiceBroker = container.GetSecureServiceBroker(options);
+
+			Export<ServiceBrokerForExportedBrokeredServices>? export = await this.ActivateBrokeredServiceAsync(serviceDescriptor.Moniker, contextualServiceBroker, options, cancellationToken).ConfigureAwait(false);
+			if (export is null)
+			{
+				return null;
+			}
+
+			IExportedBrokeredService? brokeredService = null;
+
+			try
+			{
+				serviceDescriptor = serviceDescriptor
+					.WithTraceSource(await container.GetTraceSourceForBrokeredServiceAsync(contextualServiceBroker, serviceDescriptor.Moniker, options, clientRole: false, cancellationToken).ConfigureAwait(false));
+
+				brokeredService = await export.Value.CreateBrokeredServiceAsync(cancellationToken).ConfigureAwait(false);
+				if (brokeredService is null)
+				{
+					export.Dispose();
+					return null;
+				}
+
+				T proxy = serviceDescriptor.ConstructLocalProxy((T)brokeredService);
+
+				// Arrange for proxy disposal to also dispose of our export to avoid a MEF leak.
+				// It's critical that the client disposing of the proxy lead to the disposal of the MEF Export<T>
+				// or else MEF will never release a strong reference it holds on the Export<T> as a non-shared part.
+				// But disposing the Export<T> also leads to MEF disposing the exported brokered service, which disposing of the proxy also did.
+				// This means the exported brokered service instance will be disposed of twice.
+				// This isn't great, but it's permissible (https://docs.microsoft.com/en-us/dotnet/api/system.idisposable.dispose?redirectedfrom=MSDN&view=net-6.0#remarks)
+				// "If an object's Dispose method is called more than once, the object must ignore all calls after the first one."
+				// If we ever have to avoid disposing twice, we could use dynamic code generation to wrap the proxy we have
+				// (which is itself a dynamic code gen class) in another proxy that redirects the Dispose call but forwards all others.
+				((INotifyDisposable)proxy).Disposed += (s, e) => export.Dispose();
+
+				return proxy;
+			}
+			catch
+			{
+				(brokeredService as IDisposable)?.Dispose();
+				export.Dispose();
+				throw;
+			}
+		}
+		catch (Exception ex)
+		{
+			throw new ServiceActivationFailedException(serviceDescriptor.Moniker, ex);
+		}
+	}
+
+	/// <summary>
+	/// Gets the global brokered service container.
+	/// </summary>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>The global brokered service container.</returns>
+	protected abstract Task<GlobalBrokeredServiceContainer> GetBrokeredServiceContainerAsync(CancellationToken cancellationToken);
+
+	private static ServiceMoniker CreateServiceMoniker(IBrokeredServicesExportMetadata metadata, int index)
+	{
+		return new ServiceMoniker(metadata.ServiceName[index], metadata.ServiceVersion[index] is string v ? new Version(v) : null);
+	}
+
+	/// <summary>
+	/// Creates an instance of a MEF sharing boundary within which a brokered service with the specified moniker will be activated.
+	/// </summary>
+	/// <param name="serviceMoniker">The moniker of the required service.</param>
+	/// <param name="contextualServiceBroker">The service broker that is created specifically for this brokered service.</param>
+	/// <param name="serviceActivationOptions">The activation options to use with this service.</param>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>The MEF export representing this sharing boundary.</returns>
+	private async ValueTask<Export<ServiceBrokerForExportedBrokeredServices>?> ActivateBrokeredServiceAsync(ServiceMoniker serviceMoniker, IServiceBroker contextualServiceBroker, ServiceActivationOptions serviceActivationOptions, CancellationToken cancellationToken)
+	{
+		Export<ServiceBrokerForExportedBrokeredServices> sb = this.ServiceBrokerFactory.CreateExport();
+		IAuthorizationService? authorizationService = null;
+
+		try
+		{
+			sb.Value.InnerServiceBroker = contextualServiceBroker;
+			sb.Value.ServiceActivationOptions = serviceActivationOptions;
+			sb.Value.ActivatedMoniker = serviceMoniker;
+
+			ServiceRegistration serviceRegistration = this.serviceRegistration[serviceMoniker];
+			authorizationService = await contextualServiceBroker.GetProxyAsync<IAuthorizationService>(FrameworkServices.Authorization, cancellationToken).ConfigureAwait(false);
+			Assumes.Present(authorizationService);
+			if (!serviceRegistration.AllowGuestClients && !await authorizationService.CheckAuthorizationAsync(ClientIsOwnerProtectedOperation, cancellationToken).ConfigureAwait(false))
+			{
+				sb.Dispose();
+				return null;
+			}
+
+			sb.Value.AuthorizationServiceClient = new AuthorizationServiceClient(authorizationService);
+			authorizationService = null; // we no longer own this instance, so don't dispose it later.
+
+			return sb;
+		}
+		catch
+		{
+			sb.Dispose();
+			throw;
+		}
+		finally
+		{
+			(authorizationService as IDisposable)?.Dispose();
+		}
+	}
+
+	/// <summary>
+	/// Initializes internal data structures after MEF has set importing properties.
+	/// </summary>
+	private void Initialize()
+	{
+		// Only run once.
+		if (this.serviceMonikers.Count > 0)
+		{
+			return;
+		}
+
+		var monikers = this.serviceMonikers.ToBuilder();
+		var registrations = this.serviceRegistration.ToBuilder();
+
+		// Create one sharing boundary temporarily so we can inspect the metadata on the exports within that boundary.
+		using Export<ServiceBrokerForExportedBrokeredServices> lowerExport = this.ServiceBrokerFactory.CreateExport();
+
+		foreach (IBrokeredServicesExportMetadata exportMetadata in lowerExport.Value.ExportedServiceMetadata)
+		{
+			for (int i = 0; i < exportMetadata.ServiceName.Length; i++)
+			{
+				ServiceMoniker moniker = CreateServiceMoniker(exportMetadata, i);
+
+				// When a brokered service MEF part exports itself more than once with distinct monikers, each moniker appears as its own export,
+				// but each export also contains metadata for every moniker on that export.
+				// To keep the MEF part simple, we accommodate this by just swallowing the duplicates.
+				// This means that if two distinct MEF parts were both exporting the same moniker we would quietly pick one in a non-deterministic way
+				// rather than detect and report it. :(
+				if (monikers.Add(moniker))
+				{
+					registrations.Add(moniker, new ServiceRegistration(exportMetadata.Audience[i], null, exportMetadata.AllowTransitiveGuestClients[i]));
+				}
+			}
+		}
+
+		this.serviceMonikers = monikers.ToImmutable();
+		this.serviceRegistration = registrations.ToImmutable();
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/ServiceBrokerUtilities.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/ServiceBrokerUtilities.cs
@@ -1,0 +1,89 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Buffers;
+using System.IO.Pipelines;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+internal static class ServiceBrokerUtilities
+{
+	/// <summary>
+	/// Creates an object whose <see cref="object.ToString"/> method defers to a given delegate.
+	/// </summary>
+	/// <param name="formatter">
+	/// The delegate that will construct the string.
+	/// This may be called concurrently or repeatedly.
+	/// After returning a non-null value it will not be called again as its value will be cached.
+	/// </param>
+	/// <returns>An object whose <see cref="object.ToString"/> will invoke the <paramref name="formatter"/>.</returns>
+	internal static object DeferredFormatting(Func<string?> formatter)
+	{
+		return new DeferredFormatter(formatter);
+	}
+
+	internal static async Task LinkAsync(PipeReader reader, PipeWriter writer, CancellationToken cancellationToken)
+	{
+		Requires.NotNull(reader, nameof(reader));
+		Requires.NotNull(writer, nameof(writer));
+
+		try
+		{
+			while (!cancellationToken.IsCancellationRequested)
+			{
+				ReadResult result = await reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+				writer.WriteToPipe(result.Buffer);
+				reader.AdvanceTo(result.Buffer.End);
+				await writer.FlushAsync(cancellationToken).ConfigureAwait(false);
+				if (result.IsCompleted)
+				{
+					await writer.CompleteAsync().ConfigureAwait(false);
+					break;
+				}
+			}
+
+			await writer.CompleteAsync().ConfigureAwait(false);
+		}
+		catch (Exception ex)
+		{
+			await writer.CompleteAsync(ex).ConfigureAwait(false);
+		}
+	}
+
+	internal static void Deconstruct<TKey, TValue>(this KeyValuePair<TKey, TValue> pair, out TKey key, out TValue value)
+	{
+		key = pair.Key;
+		value = pair.Value;
+	}
+
+	/// <summary>
+	/// Copies a sequence of bytes to a <see cref="PipeWriter"/>.
+	/// </summary>
+	/// <param name="writer">The writer to use.</param>
+	/// <param name="sequence">The sequence to read.</param>
+	private static void WriteToPipe(this PipeWriter writer, ReadOnlySequence<byte> sequence)
+	{
+		Requires.NotNull(writer, nameof(writer));
+
+		foreach (ReadOnlyMemory<byte> sourceMemory in sequence)
+		{
+			writer.Write(sourceMemory.Span);
+		}
+	}
+
+	private class DeferredFormatter
+	{
+		private readonly Func<string?> formatter;
+
+		private string? realizedString;
+
+		internal DeferredFormatter(Func<string?> formatter)
+		{
+			Requires.NotNull(formatter, nameof(formatter));
+			this.formatter = formatter;
+		}
+
+		public override string? ToString() => this.realizedString ?? (this.realizedString = this.formatter());
+	}
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/ServiceRegistration.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/ServiceRegistration.cs
@@ -1,0 +1,83 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+/// <summary>
+/// Brokered service registration information.
+/// </summary>
+[DebuggerDisplay("{" + nameof(DebuggerDisplay) + "}")]
+public class ServiceRegistration
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ServiceRegistration"/> class.
+	/// </summary>
+	/// <param name="audience">The audience that may consume this brokered service.</param>
+	/// <param name="profferingPackageId">The ID of the brokered service host that may need to be activated in order to proffer the service factory.</param>
+	/// <param name="allowGuestClients">A value indicating whether remote guests should be allowed to access this service.</param>
+	public ServiceRegistration(ServiceAudience audience, object? profferingPackageId, bool allowGuestClients)
+	{
+		this.Audience = audience;
+		this.ProfferingPackageId = profferingPackageId;
+		this.AllowGuestClients = allowGuestClients;
+	}
+
+	/// <summary>
+	/// Gets the intended audiences for this service.
+	/// </summary>
+	public ServiceAudience Audience { get; }
+
+	/// <summary>
+	/// Gets a value indicating whether this service is exposed to non-Owner clients.
+	/// </summary>
+	public bool AllowGuestClients { get; }
+
+	/// <summary>
+	/// Gets the ID of the package to load so that this service will actually be proffered.
+	/// </summary>
+	/// <remarks>
+	/// If this is null, the <see cref="LoadProfferingPackageAsync(CancellationToken)"/> method can be assumed to be a no-op.
+	/// </remarks>
+	public object? ProfferingPackageId { get; }
+
+	/// <summary>
+	/// Gets a value indicating whether this service is exposed to local clients relative to itself.
+	/// </summary>
+	public bool IsExposedLocally => (this.Audience & ServiceAudience.Local) != ServiceAudience.None;
+
+	/// <summary>
+	/// Gets a value indicating whether this service is exposed to remote clients relative to itself.
+	/// </summary>
+	public bool IsExposedRemotely => (this.Audience & (ServiceAudience.LiveShareGuest | ServiceAudience.RemoteExclusiveClient | ServiceAudience.RemoteExclusiveServer)) != ServiceAudience.None;
+
+	/// <summary>
+	/// Gets the string to use in a <see cref="DebuggerDisplayAttribute"/>.
+	/// </summary>
+	[DebuggerBrowsable(DebuggerBrowsableState.Never)]
+	protected string DebuggerDisplay => $"{this.Audience} ({this.ProfferingPackageId}) [{(this.AllowGuestClients ? "AllowGuestClients" : string.Empty)}]";
+
+	/// <inheritdoc />
+	public override string ToString()
+	{
+		return $"{nameof(ServiceAudience)}: {this.Audience}, {nameof(this.AllowGuestClients)}: {this.AllowGuestClients}, {nameof(this.ProfferingPackageId)}: {this.ProfferingPackageId}";
+	}
+
+	/// <summary>
+	/// Gets a value indicating whether this service is approved for consuming by a given audience.
+	/// </summary>
+	/// <param name="consumingAudience">The candidate audience that would like to get this service.</param>
+	/// <returns>A value indicating whether the service permits access by the given audience.</returns>
+	internal bool IsExposedTo(ServiceAudience consumingAudience) => (consumingAudience & this.Audience) == consumingAudience;
+
+	/// <summary>
+	/// Triggers the call to <see cref="IBrokeredServiceContainer.Proffer(ServiceRpcDescriptor, BrokeredServiceFactory)"/>
+	/// the service represented by this registration if the service has not yet been proffered.
+	/// </summary>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>A task that tracks the async operation.</returns>
+	protected internal virtual Task LoadProfferingPackageAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/ServiceSource.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/ServiceSource.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+/// <summary>
+/// Enumerates the possible sources of a brokered service.
+/// </summary>
+public enum ServiceSource
+{
+	/// <summary>
+	/// The services are proffered from within this process.
+	/// </summary>
+	SameProcess,
+
+	/// <summary>
+	/// The services are proffered by local (and trusted) sources, outside this process.
+	/// </summary>
+	OtherProcessOnSameMachine,
+
+	/// <summary>
+	/// The services are proffered by a remote server (e.g. Live Share host) that is under the control of the same user account as the local one (the guest who is joining the session).
+	/// </summary>
+	TrustedServer,
+
+	/// <summary>
+	/// The services are proffered by a remote server (e.g. Live Share host) that is NOT under the control of the same user account as the local one (the guest who is joining the session).
+	/// </summary>
+	UntrustedServer,
+
+	/// <summary>
+	/// The services are proffered by a remote server that is under the control of the same user account as the local one
+	/// using an exclusive connection (that isn't the traditional Live Share sharing session).
+	/// For example a Codespace server.
+	/// </summary>
+	TrustedExclusiveServer,
+
+	/// <summary>
+	/// The services are proffered by a remote <em>client</em> under the control of the same user account as the local one.
+	/// This is a special 1:1 relationship.
+	/// For example the client of a Codespace.
+	/// </summary>
+	TrustedExclusiveClient,
+}

--- a/src/Microsoft.ServiceHub.Framework/Container/WellKnownProtectedOperations.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/WellKnownProtectedOperations.cs
@@ -1,0 +1,21 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.ServiceHub.Framework.Services;
+
+namespace Microsoft.VisualStudio.Shell.ServiceBroker;
+
+internal static class WellKnownProtectedOperations
+{
+	/// <summary>
+	/// The moniker used to represent a check for whether the client is owned by the same user account that owns the host
+	/// and therefore merits full owner trust permissions.
+	/// </summary>
+	internal const string ClientIsOwner = "ClientIsOwnerOfHost";
+
+	/// <summary>
+	/// Creates a new <see cref="ProtectedOperation"/> that represents a <see cref="ClientIsOwner"/> operation.
+	/// </summary>
+	/// <returns>An instance of <see cref="ProtectedOperation"/> that may be passed to <see cref="IAuthorizationService.CheckAuthorizationAsync(ProtectedOperation, System.Threading.CancellationToken)"/>.</returns>
+	internal static ProtectedOperation CreateClientIsOwner() => new ProtectedOperation(ClientIsOwner);
+}

--- a/src/Microsoft.ServiceHub.Framework/Extensions/ServiceManagerReflectionHelpers.cs
+++ b/src/Microsoft.ServiceHub.Framework/Extensions/ServiceManagerReflectionHelpers.cs
@@ -25,7 +25,7 @@ internal static class ServiceManagerReflectionHelpers
 	/// </devremarks>
 	internal static async Task<IServiceBroker?> GetServiceBrokerAsync(ServiceActivationOptions options, CancellationToken cancellationToken)
 	{
-		var serverPipeName = options.GetServiceBrokerServerPipeName();
+		string serverPipeName = options.GetServiceBrokerServerPipeName();
 
 		if (!string.IsNullOrEmpty(serverPipeName))
 		{
@@ -112,7 +112,7 @@ internal static class ServiceManagerReflectionHelpers
 					options.ClientRpcTarget = connection.ConstructRpcClient(serviceDescriptor.ClientInterface);
 				}
 
-				var serviceFactoryResult = await getRpcObject(options).ConfigureAwait(false);
+				object serviceFactoryResult = await getRpcObject(options).ConfigureAwait(false);
 
 				connection.AddLocalRpcTarget(serviceFactoryResult);
 				connection.StartListening();
@@ -157,7 +157,7 @@ internal static class ServiceManagerReflectionHelpers
 	/// <returns>The value that is associated for the requested service version.</returns>
 	internal static string GetVersionInformationFromServiceActivationOptions(ServiceActivationOptions serviceActivationOptions)
 	{
-		var keyValue = string.Empty;
+		string? keyValue = string.Empty;
 		serviceActivationOptions.ActivationArguments?.TryGetValue("__servicehub__RequestedServiceVersion", out keyValue);
 
 		return keyValue ?? string.Empty;
@@ -206,7 +206,7 @@ internal static class ServiceManagerReflectionHelpers
 		if (options.ActivationArguments is not null && options.ActivationArguments.ContainsKey(ServiceHubRemoteServiceBrokerPipeNameActivationArgument))
 		{
 			var activationOptions = new Dictionary<string, string>();
-			foreach (var option in options.ActivationArguments!.Keys)
+			foreach (string option in options.ActivationArguments!.Keys)
 			{
 				if (!option.Equals(ServiceHubRemoteServiceBrokerPipeNameActivationArgument, StringComparison.OrdinalIgnoreCase)
 					&& options.ActivationArguments.TryGetValue(option, out string? value))

--- a/src/Microsoft.ServiceHub.Framework/FrameworkServices.cs
+++ b/src/Microsoft.ServiceHub.Framework/FrameworkServices.cs
@@ -49,9 +49,7 @@ public static class FrameworkServices
 		/// </summary>
 		/// <inheritdoc cref="ServiceJsonRpcDescriptor(ServiceMoniker, Formatters, MessageDelimiters)" />
 		public CamelCaseTransformingDescriptor(ServiceMoniker serviceMoniker, Formatters formatter, MessageDelimiters messageDelimiter)
-#pragma warning disable CS0618 // Type or member is obsolete. Support for legacy calls.
 			: base(serviceMoniker, formatter, messageDelimiter)
-#pragma warning restore CS0618 // Type or member is obsolete
 		{
 		}
 

--- a/src/Microsoft.ServiceHub.Framework/IpcRelayServiceBroker.cs
+++ b/src/Microsoft.ServiceHub.Framework/IpcRelayServiceBroker.cs
@@ -1,13 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Buffers;
 using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO.Pipelines;
 using Microsoft.VisualStudio.Threading;
-using Nerdbank.Streams;
-using static Nerdbank.Streams.MultiplexingStream;
 using IAsyncDisposable = System.IAsyncDisposable;
 
 namespace Microsoft.ServiceHub.Framework;

--- a/src/Microsoft.ServiceHub.Framework/IpcServer.cs
+++ b/src/Microsoft.ServiceHub.Framework/IpcServer.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.IO.Pipes;
-using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.ServiceHub.Framework;

--- a/src/Microsoft.ServiceHub.Framework/Microsoft.ServiceHub.Framework.csproj
+++ b/src/Microsoft.ServiceHub.Framework/Microsoft.ServiceHub.Framework.csproj
@@ -8,10 +8,13 @@
   <ItemGroup>
     <PackageReference Include="IsExternalInit" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" PrivateAssets="all" />
+    <!-- Workaround https://github.com/dotnet/roslyn-sdk/issues/1053 by downgrading the VS-MEF version we deploy. -->
+    <PackageReference Include="Microsoft.VisualStudio.Composition" VersionOverride="16.1.8" />
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Windows.CsWin32" PrivateAssets="all" />
     <PackageReference Include="StreamJsonRpc" />
     <PackageReference Include="System.Collections.Immutable" />
+    <PackageReference Include="TraceSource.ActivityTracing" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Microsoft.ServiceHub.Framework/NativeMethods.txt
+++ b/src/Microsoft.ServiceHub.Framework/NativeMethods.txt
@@ -1,2 +1,3 @@
+GetNamedPipeClientProcessId
 HRESULT_FROM_WIN32
 NMPWAIT_NOWAIT

--- a/src/Microsoft.ServiceHub.Framework/PolyfillExtensions.cs
+++ b/src/Microsoft.ServiceHub.Framework/PolyfillExtensions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Runtime.Versioning;
-
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1403 // File may only contain a single namespace
 

--- a/src/Microsoft.ServiceHub.Framework/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.ServiceHub.Framework/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
-﻿Microsoft.ServiceHub.Framework.IIpcServer
+﻿abstract Microsoft.VisualStudio.Shell.ServiceBroker.ServiceBrokerOfExportedServices.GetBrokeredServiceContainerAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer!>!
+abstract Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.LocalUserCredentials.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+Microsoft.ServiceHub.Framework.IIpcServer
 Microsoft.ServiceHub.Framework.IIpcServer.Completion.get -> System.Threading.Tasks.Task!
 Microsoft.ServiceHub.Framework.IIpcServer.Name.get -> string!
 Microsoft.ServiceHub.Framework.IIpcServer.TraceSource.get -> System.Diagnostics.TraceSource!
@@ -22,9 +24,146 @@ Microsoft.ServiceHub.Framework.ServerFactory.ServerOptions.TraceSource.get -> Sy
 Microsoft.ServiceHub.Framework.ServerFactory.ServerOptions.TraceSource.init -> void
 Microsoft.ServiceHub.Framework.ServiceActivationOptions.CultureApplication.CultureApplication() -> void
 Microsoft.ServiceHub.Framework.ServiceBrokerClient.Rental<T>.Rental() -> void
+Microsoft.ServiceHub.Framework.Services.IBrokeredServiceManifest
+Microsoft.ServiceHub.Framework.Services.IBrokeredServiceManifest.GetAvailableServicesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyCollection<Microsoft.ServiceHub.Framework.ServiceMoniker!>!>
+Microsoft.ServiceHub.Framework.Services.IBrokeredServiceManifest.GetAvailableVersionsAsync(string! serviceName, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Collections.Immutable.ImmutableSortedSet<System.Version?>!>
+Microsoft.VisualStudio.Shell.ServiceBroker.AuthorizingBrokeredServiceFactory
+Microsoft.VisualStudio.Shell.ServiceBroker.BrokeredServiceFactory
+Microsoft.VisualStudio.Shell.ServiceBroker.ClientCredentialsPolicy
+Microsoft.VisualStudio.Shell.ServiceBroker.ClientCredentialsPolicy.FilterOverridesRequest = 1 -> Microsoft.VisualStudio.Shell.ServiceBroker.ClientCredentialsPolicy
+Microsoft.VisualStudio.Shell.ServiceBroker.ClientCredentialsPolicy.RequestOverridesDefault = 0 -> Microsoft.VisualStudio.Shell.ServiceBroker.ClientCredentialsPolicy
+Microsoft.VisualStudio.Shell.ServiceBroker.ExportBrokeredServiceAttribute
+Microsoft.VisualStudio.Shell.ServiceBroker.ExportBrokeredServiceAttribute.AllowTransitiveGuestClients.get -> bool
+Microsoft.VisualStudio.Shell.ServiceBroker.ExportBrokeredServiceAttribute.AllowTransitiveGuestClients.set -> void
+Microsoft.VisualStudio.Shell.ServiceBroker.ExportBrokeredServiceAttribute.Audience.get -> Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience
+Microsoft.VisualStudio.Shell.ServiceBroker.ExportBrokeredServiceAttribute.Audience.set -> void
+Microsoft.VisualStudio.Shell.ServiceBroker.ExportBrokeredServiceAttribute.ExportBrokeredServiceAttribute(string! name, string? version) -> void
+Microsoft.VisualStudio.Shell.ServiceBroker.ExportBrokeredServiceAttribute.ServiceName.get -> string!
+Microsoft.VisualStudio.Shell.ServiceBroker.ExportBrokeredServiceAttribute.ServiceVersion.get -> string?
+Microsoft.VisualStudio.Shell.ServiceBroker.IBrokeredServiceContainer
+Microsoft.VisualStudio.Shell.ServiceBroker.IBrokeredServiceContainer.GetFullAccessServiceBroker() -> Microsoft.ServiceHub.Framework.IServiceBroker!
+Microsoft.VisualStudio.Shell.ServiceBroker.IBrokeredServiceContainer.Proffer(Microsoft.ServiceHub.Framework.ServiceRpcDescriptor! serviceDescriptor, Microsoft.VisualStudio.Shell.ServiceBroker.AuthorizingBrokeredServiceFactory! factory) -> System.IDisposable!
+Microsoft.VisualStudio.Shell.ServiceBroker.IBrokeredServiceContainer.Proffer(Microsoft.ServiceHub.Framework.ServiceRpcDescriptor! serviceDescriptor, Microsoft.VisualStudio.Shell.ServiceBroker.BrokeredServiceFactory! factory) -> System.IDisposable!
+Microsoft.VisualStudio.Shell.ServiceBroker.IBrokeredServiceContainerDiagnostics
+Microsoft.VisualStudio.Shell.ServiceBroker.IBrokeredServiceContainerDiagnostics.ExportDiagnosticsAsync(string! filePath, Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience serviceAudience, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Shell.ServiceBroker.IBrokeredServiceContainerInternal
+Microsoft.VisualStudio.Shell.ServiceBroker.IBrokeredServiceContainerInternal.GetLimitedAccessServiceBroker(Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience audience, System.Collections.Generic.IReadOnlyDictionary<string!, string!>! clientCredentials, Microsoft.VisualStudio.Shell.ServiceBroker.ClientCredentialsPolicy credentialPolicy) -> Microsoft.ServiceHub.Framework.IServiceBroker!
+Microsoft.VisualStudio.Shell.ServiceBroker.IBrokeredServiceContainerInternal.LocalUserCredentials.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
+Microsoft.VisualStudio.Shell.ServiceBroker.IExportedBrokeredService
+Microsoft.VisualStudio.Shell.ServiceBroker.IExportedBrokeredService.Descriptor.get -> Microsoft.ServiceHub.Framework.ServiceRpcDescriptor!
+Microsoft.VisualStudio.Shell.ServiceBroker.IExportedBrokeredService.InitializeAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience
+Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience.AllClientsIncludingGuests = Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience.Local | Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience.RemoteExclusiveClient | Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience.LiveShareGuest -> Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience
+Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience.LiveShareGuest = 1024 -> Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience
+Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience.Local = 3 -> Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience
+Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience.None = 0 -> Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience
+Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience.Process = 1 -> Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience
+Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience.PublicSdk = 268435456 -> Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience
+Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience.RemoteExclusiveClient = 256 -> Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience
+Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience.RemoteExclusiveServer = 2048 -> Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience
+Microsoft.VisualStudio.Shell.ServiceBroker.ServiceBrokerOfExportedServices
+Microsoft.VisualStudio.Shell.ServiceBroker.ServiceBrokerOfExportedServices.RegisterAndProfferServices(Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer! container) -> void
+Microsoft.VisualStudio.Shell.ServiceBroker.ServiceBrokerOfExportedServices.RegisterAndProfferServicesAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Shell.ServiceBroker.ServiceBrokerOfExportedServices.ServiceBrokerOfExportedServices() -> void
+Microsoft.VisualStudio.Shell.ServiceBroker.SVsBrokeredServiceContainer
+Microsoft.VisualStudio.Shell.ServiceBroker.SVsFullAccessServiceBroker
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ApplyChaosMonkeyConfigurationAsync(string! chaosMonkeyConfigurationPath, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ExportDiagnosticsAsync(string! filePath, Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience serviceAudience, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.GetFullAccessServiceBroker() -> Microsoft.ServiceHub.Framework.IServiceBroker!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.GetLimitedAccessRemoteServiceBroker(Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience audience, System.Collections.Generic.IReadOnlyDictionary<string!, string!>! clientCredentials, Microsoft.VisualStudio.Shell.ServiceBroker.ClientCredentialsPolicy credentialPolicy) -> Microsoft.ServiceHub.Framework.IRemoteServiceBroker!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.GetLimitedAccessServiceBroker(Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience audience, System.Collections.Generic.IReadOnlyDictionary<string!, string!>! clientCredentials, Microsoft.VisualStudio.Shell.ServiceBroker.ClientCredentialsPolicy credentialPolicy) -> Microsoft.ServiceHub.Framework.IServiceBroker!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.GetSecureServiceBroker(Microsoft.ServiceHub.Framework.ServiceActivationOptions options) -> Microsoft.ServiceHub.Framework.IServiceBroker!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.GetServicesThatMayBeExpected(Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource remoteSource) -> System.Collections.Generic.IEnumerable<Microsoft.ServiceHub.Framework.ServiceMoniker!>!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.GetTraceSourceForBrokeredServiceAsync(Microsoft.ServiceHub.Framework.IServiceBroker! serviceBroker, Microsoft.ServiceHub.Framework.ServiceMoniker! serviceMoniker, Microsoft.ServiceHub.Framework.ServiceActivationOptions options, bool clientRole, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Diagnostics.TraceSource?>
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.GlobalBrokeredServiceContainer(System.Collections.Immutable.ImmutableDictionary<Microsoft.ServiceHub.Framework.ServiceMoniker!, Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceRegistration!>! services, bool isClientOfExclusiveServer, Microsoft.VisualStudio.Threading.JoinableTaskFactory? joinableTaskFactory, System.Diagnostics.TraceSource! traceSource) -> void
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.IProffered
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.IProffered.Monikers.get -> System.Collections.Immutable.ImmutableHashSet<Microsoft.ServiceHub.Framework.ServiceMoniker!>!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.IProffered.Source.get -> Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.Proffer(Microsoft.ServiceHub.Framework.IServiceBroker! serviceBroker, System.Collections.Generic.IReadOnlyCollection<Microsoft.ServiceHub.Framework.ServiceMoniker!>! serviceMonikers) -> System.IDisposable!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.Proffer(Microsoft.ServiceHub.Framework.ServiceRpcDescriptor! serviceDescriptor, Microsoft.VisualStudio.Shell.ServiceBroker.AuthorizingBrokeredServiceFactory! factory) -> System.IDisposable!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.Proffer(Microsoft.ServiceHub.Framework.ServiceRpcDescriptor! serviceDescriptor, Microsoft.VisualStudio.Shell.ServiceBroker.BrokeredServiceFactory! factory) -> System.IDisposable!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedRemoteServiceBroker
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedRemoteServiceBroker.AvailabilityChanged -> System.EventHandler<Microsoft.ServiceHub.Framework.BrokeredServicesChangedEventArgs!>?
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedRemoteServiceBroker.Dispose() -> void
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedRemoteServiceBroker.GetPipeAsync(Microsoft.ServiceHub.Framework.ServiceMoniker! serviceMoniker, Microsoft.ServiceHub.Framework.ServiceActivationOptions options, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.IO.Pipelines.IDuplexPipe?>
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedRemoteServiceBroker.GetProxyAsync<T>(Microsoft.ServiceHub.Framework.ServiceRpcDescriptor! serviceDescriptor, Microsoft.ServiceHub.Framework.ServiceActivationOptions options, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<T?>
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedRemoteServiceBroker.Monikers.get -> System.Collections.Immutable.ImmutableHashSet<Microsoft.ServiceHub.Framework.ServiceMoniker!>!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedRemoteServiceBroker.Source.get -> Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedServiceBroker
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedServiceBroker.AvailabilityChanged -> System.EventHandler<Microsoft.ServiceHub.Framework.BrokeredServicesChangedEventArgs!>?
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedServiceBroker.Dispose() -> void
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedServiceBroker.GetPipeAsync(Microsoft.ServiceHub.Framework.ServiceMoniker! serviceMoniker, Microsoft.ServiceHub.Framework.ServiceActivationOptions options, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.IO.Pipelines.IDuplexPipe?>
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedServiceBroker.GetProxyAsync<T>(Microsoft.ServiceHub.Framework.ServiceRpcDescriptor! serviceDescriptor, Microsoft.ServiceHub.Framework.ServiceActivationOptions options, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<T?>
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedServiceBroker.Monikers.get -> System.Collections.Immutable.ImmutableHashSet<Microsoft.ServiceHub.Framework.ServiceMoniker!>!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedServiceBroker.Source.get -> Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedServiceFactory
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedServiceFactory.AvailabilityChanged -> System.EventHandler<Microsoft.ServiceHub.Framework.BrokeredServicesChangedEventArgs!>?
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedServiceFactory.Dispose() -> void
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedServiceFactory.Monikers.get -> System.Collections.Immutable.ImmutableHashSet<Microsoft.ServiceHub.Framework.ServiceMoniker!>!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedServiceFactory.Source.get -> Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferIntrinsicService(Microsoft.ServiceHub.Framework.ServiceRpcDescriptor! serviceDescriptor, Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceRegistration! newRegistration, Microsoft.VisualStudio.Shell.ServiceBroker.BrokeredServiceFactory! factory) -> System.IDisposable!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferRemoteBroker(Microsoft.ServiceHub.Framework.IRemoteServiceBroker! serviceBroker, Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource source, System.Collections.Immutable.ImmutableHashSet<Microsoft.ServiceHub.Framework.ServiceMoniker!>? serviceMonikers = null) -> System.IDisposable!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferRemoteBroker(Microsoft.ServiceHub.Framework.IRemoteServiceBroker! serviceBroker, Nerdbank.Streams.MultiplexingStream? multiplexingStream, Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource source, System.Collections.Immutable.ImmutableHashSet<Microsoft.ServiceHub.Framework.ServiceMoniker!>? serviceMonikers = null) -> System.IDisposable!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferRemoteBroker(Microsoft.ServiceHub.Framework.IServiceBroker! serviceBroker, Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource source, System.Collections.Immutable.ImmutableHashSet<Microsoft.ServiceHub.Framework.ServiceMoniker!>? serviceMonikers = null) -> System.IDisposable!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.RegisteredServices.get -> System.Collections.Immutable.ImmutableDictionary<Microsoft.ServiceHub.Framework.ServiceMoniker!, Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceRegistration!>!
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.RegisterServices(System.Collections.Generic.IReadOnlyDictionary<Microsoft.ServiceHub.Framework.ServiceMoniker!, Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceRegistration!>! services) -> void
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.RequestResult
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.RequestResult.Declined = 2 -> Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.RequestResult
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.RequestResult.DeclinedNotFound = 4 -> Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.RequestResult
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.RequestResult.Fulfilled = 1 -> Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.RequestResult
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.RequestType
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.RequestType.Pipe = 1 -> Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.RequestType
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.RequestType.Proxy = 0 -> Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.RequestType
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.TraceEvents
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.TraceEvents.EventHandlerFaulted = 4 -> Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.TraceEvents
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.TraceEvents.LoadPackage = 3 -> Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.TraceEvents
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.TraceEvents.Proffered = 1 -> Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.TraceEvents
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.TraceEvents.Registered = 0 -> Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.TraceEvents
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.TraceEvents.Request = 2 -> Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.TraceEvents
+Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.UnregisterServices(System.Collections.Generic.IEnumerable<Microsoft.ServiceHub.Framework.ServiceMoniker!>! services) -> void
+Microsoft.VisualStudio.Utilities.ServiceBroker.IMissingServiceDiagnosticsService
+Microsoft.VisualStudio.Utilities.ServiceBroker.IMissingServiceDiagnosticsService.AnalyzeMissingServiceAsync(Microsoft.ServiceHub.Framework.ServiceMoniker! missingServiceMoniker, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<Microsoft.VisualStudio.Utilities.ServiceBroker.MissingServiceAnalysis!>!
+Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode
+Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode.ChaosConfigurationDeniedRequest = 2 -> Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode
+Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode.LocalServiceHiddenOnExclusiveClient = 3 -> Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode
+Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode.LocalServiceHiddenOnRemoteClient = 8 -> Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode
+Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode.NoExplanation = 0 -> Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode
+Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode.NotLocallyRegistered = 1 -> Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode
+Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode.ServiceAudienceMismatch = 4 -> Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode
+Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode.ServiceFactoryFault = 7 -> Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode
+Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode.ServiceFactoryNotProffered = 5 -> Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode
+Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode.ServiceFactoryReturnedNull = 6 -> Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode
+Microsoft.VisualStudio.Utilities.ServiceBroker.MissingServiceAnalysis
+Microsoft.VisualStudio.Utilities.ServiceBroker.MissingServiceAnalysis.ErrorCode.get -> Microsoft.VisualStudio.Utilities.ServiceBroker.MissingBrokeredServiceErrorCode
+Microsoft.VisualStudio.Utilities.ServiceBroker.MissingServiceAnalysis.ExpectedSource.get -> Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource?
+Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceRegistration
+Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceRegistration.AllowGuestClients.get -> bool
+Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceRegistration.Audience.get -> Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience
+Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceRegistration.DebuggerDisplay.get -> string!
+Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceRegistration.IsExposedLocally.get -> bool
+Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceRegistration.IsExposedRemotely.get -> bool
+Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceRegistration.ProfferingPackageId.get -> object?
+Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceRegistration.ServiceRegistration(Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience audience, object? profferingPackageId, bool allowGuestClients) -> void
+Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource
+Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource.OtherProcessOnSameMachine = 1 -> Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource
+Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource.SameProcess = 0 -> Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource
+Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource.TrustedExclusiveClient = 5 -> Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource
+Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource.TrustedExclusiveServer = 4 -> Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource
+Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource.TrustedServer = 2 -> Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource
+Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource.UntrustedServer = 3 -> Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceSource
+override Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceRegistration.ToString() -> string!
 static Microsoft.ServiceHub.Framework.ServerFactory.ConnectAsync(string! pipeName, Microsoft.ServiceHub.Framework.ServerFactory.ClientOptions options, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 static Microsoft.ServiceHub.Framework.ServerFactory.ConnectAsync(string! pipeName, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.IO.Stream!>!
 static Microsoft.ServiceHub.Framework.ServerFactory.Create(System.Func<System.IO.Stream!, System.Threading.Tasks.Task!>! onConnectedCallback, Microsoft.ServiceHub.Framework.ServerFactory.ServerOptions options = default(Microsoft.ServiceHub.Framework.ServerFactory.ServerOptions)) -> Microsoft.ServiceHub.Framework.IIpcServer!
 static Microsoft.ServiceHub.Framework.ServerFactory.CreateAsync(string! pipeName, System.Diagnostics.TraceSource? logger, System.Func<System.IO.Stream!, System.Threading.Tasks.Task!>! onConnectedCallback) -> System.Threading.Tasks.Task<(System.IDisposable! Server, string! ServerName)>!
 static Microsoft.ServiceHub.Framework.ServerFactory.PrependPipePrefix(string! leafPipeName) -> string!
+static Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.MissingServiceDiagnostics.get -> Microsoft.ServiceHub.Framework.ServiceRpcDescriptor!
+static readonly Microsoft.ServiceHub.Framework.FrameworkServices.RemoteBrokeredServiceManifest -> Microsoft.ServiceHub.Framework.ServiceRpcDescriptor!
 virtual Microsoft.ServiceHub.Framework.IpcRelayServiceBroker.Dispose(bool disposing) -> void
+virtual Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.GetTraceSourceForConnectionAsync(Microsoft.ServiceHub.Framework.IServiceBroker! serviceBroker, Microsoft.ServiceHub.Framework.ServiceMoniker! serviceMoniker, Microsoft.ServiceHub.Framework.ServiceActivationOptions options, bool clientRole, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.Diagnostics.TraceSource?>
+virtual Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.OnRequestHandled(Microsoft.ServiceHub.Framework.ServiceMoniker! moniker, Microsoft.ServiceHub.Framework.ServiceRpcDescriptor? descriptor, Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.RequestType type, Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.RequestResult result, Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.IProffered? proffered) -> void
+virtual Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.Proffer(Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.IProffered! proffered) -> System.IDisposable!
+virtual Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedServiceFactory.GetPipeAsync(Microsoft.ServiceHub.Framework.ServiceMoniker! serviceMoniker, Microsoft.ServiceHub.Framework.ServiceActivationOptions options, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<System.IO.Pipelines.IDuplexPipe?>
+virtual Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.ProfferedServiceFactory.GetProxyAsync<T>(Microsoft.ServiceHub.Framework.ServiceRpcDescriptor! serviceDescriptor, Microsoft.ServiceHub.Framework.ServiceActivationOptions options, System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.ValueTask<T?>
+virtual Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceRegistration.LoadProfferingPackageAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!

--- a/src/Microsoft.ServiceHub.Framework/RemoteServiceBroker.cs
+++ b/src/Microsoft.ServiceHub.Framework/RemoteServiceBroker.cs
@@ -3,7 +3,6 @@
 
 using System.Diagnostics;
 using System.IO.Pipelines;
-using System.Net.Sockets;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
@@ -11,7 +10,6 @@ using Microsoft.ServiceHub.Framework.Services;
 using Microsoft.VisualStudio.Threading;
 using Nerdbank.Streams;
 using StreamJsonRpc;
-using IPC = System.IO.Pipes;
 
 namespace Microsoft.ServiceHub.Framework;
 
@@ -143,7 +141,6 @@ public class RemoteServiceBroker : IServiceBroker, IDisposable, System.IAsyncDis
 	/// </param>
 	/// <param name="cancellationToken">A cancellation token.</param>
 	/// <returns>An <see cref="IServiceBroker"/> that provides access to remote services.</returns>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Other parameters are significantly different, so ambiguity won't happen.")]
 	public static Task<RemoteServiceBroker> ConnectToMultiplexingServerAsync(Stream duplexStream, CancellationToken cancellationToken = default) => ConnectToMultiplexingServerAsync(duplexStream, options: null, cancellationToken: cancellationToken);
 
 	/// <summary>
@@ -161,7 +158,6 @@ public class RemoteServiceBroker : IServiceBroker, IDisposable, System.IAsyncDis
 	/// <param name="options">Options to pass along to the created <see cref="MultiplexingStream"/> on creation.</param>
 	/// <param name="cancellationToken">A cancellation token.</param>
 	/// <returns>An <see cref="IServiceBroker"/> that provides access to remote services.</returns>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Other parameters are significantly different, so ambiguity won't happen.")]
 	public static async Task<RemoteServiceBroker> ConnectToMultiplexingServerAsync(Stream duplexStream, MultiplexingStream.Options? options, CancellationToken cancellationToken = default)
 	{
 		Requires.NotNull(duplexStream, nameof(duplexStream));
@@ -199,7 +195,6 @@ public class RemoteServiceBroker : IServiceBroker, IDisposable, System.IAsyncDis
 	/// <remarks>
 	/// The <see cref="FrameworkServices.RemoteServiceBroker"/> is used as the wire protocol.
 	/// </remarks>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Other parameters are significantly different, so ambiguity won't happen.")]
 	public static async Task<RemoteServiceBroker> ConnectToMultiplexingServerAsync(IRemoteServiceBroker serviceBroker, MultiplexingStream multiplexingStream, CancellationToken cancellationToken = default)
 	{
 		Requires.NotNull(serviceBroker, nameof(serviceBroker));
@@ -234,7 +229,6 @@ public class RemoteServiceBroker : IServiceBroker, IDisposable, System.IAsyncDis
 	/// <remarks>
 	/// The <see cref="FrameworkServices.RemoteServiceBroker"/> is used as the wire protocol.
 	/// </remarks>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Other parameters are significantly different, so ambiguity won't happen.")]
 	public static Task<RemoteServiceBroker> ConnectToServerAsync(IDuplexPipe pipe, CancellationToken cancellationToken = default)
 	{
 		Requires.NotNull(pipe, nameof(pipe));
@@ -259,7 +253,6 @@ public class RemoteServiceBroker : IServiceBroker, IDisposable, System.IAsyncDis
 	/// <remarks>
 	/// The <see cref="FrameworkServices.RemoteServiceBroker"/> is used as the wire protocol.
 	/// </remarks>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Other parameters are significantly different, so ambiguity won't happen.")]
 	public static async Task<RemoteServiceBroker> ConnectToServerAsync(string pipeName, CancellationToken cancellationToken = default)
 	{
 		Requires.NotNullOrEmpty(pipeName, nameof(pipeName));
@@ -286,7 +279,6 @@ public class RemoteServiceBroker : IServiceBroker, IDisposable, System.IAsyncDis
 	/// <remarks>
 	/// The <see cref="FrameworkServices.RemoteServiceBroker"/> is used as the wire protocol.
 	/// </remarks>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Other parameters are significantly different, so ambiguity won't happen.")]
 	public static async Task<RemoteServiceBroker> ConnectToServerAsync(IRemoteServiceBroker serviceBroker, CancellationToken cancellationToken = default)
 	{
 		Requires.NotNull(serviceBroker, nameof(serviceBroker));

--- a/src/Microsoft.ServiceHub.Framework/ServerFactory.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServerFactory.cs
@@ -3,10 +3,8 @@
 
 using System.Collections.Concurrent;
 using System.Diagnostics;
-using System.Diagnostics.CodeAnalysis;
 using System.IO.Pipes;
 using System.Runtime.InteropServices;
-using Microsoft.Win32.SafeHandles;
 using Windows.Win32.Foundation;
 using static Windows.Win32.PInvoke;
 

--- a/src/Microsoft.ServiceHub.Framework/ServiceBrokerClient.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServiceBrokerClient.cs
@@ -55,7 +55,6 @@ public class ServiceBrokerClient : IDisposableObservable
 	/// </summary>
 	/// <param name="serviceBroker">The underlying service broker.</param>
 	/// <param name="joinableTaskFactory">A means to avoid deadlocks if the authorization service requires the main thread. May be null.</param>
-	[System.Diagnostics.CodeAnalysis.SuppressMessage("ApiDesign", "RS0026:Do not add multiple public overloads with optional parameters", Justification = "Other parameters are significantly different, so ambiguity won't happen.")]
 	public ServiceBrokerClient(IServiceBroker serviceBroker, JoinableTaskFactory? joinableTaskFactory = null)
 	{
 		Requires.NotNull(serviceBroker, nameof(serviceBroker));

--- a/src/Microsoft.ServiceHub.Framework/ServiceBrokerExtensions.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServiceBrokerExtensions.cs
@@ -10,7 +10,6 @@ namespace Microsoft.ServiceHub.Framework;
 /// </summary>
 public static class ServiceBrokerExtensions
 {
-#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 	/// <summary>
 	/// Requests access to some service through a client proxy.
 	/// </summary>
@@ -38,7 +37,6 @@ public static class ServiceBrokerExtensions
 		Requires.NotNull(serviceBroker, nameof(serviceBroker));
 		return serviceBroker.GetProxyAsync<T>(serviceDescriptor, default(ServiceActivationOptions), cancellationToken);
 	}
-#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 
 	/// <summary>
 	/// Requests access to some service through an <see cref="IDuplexPipe"/>.

--- a/src/Microsoft.ServiceHub.Framework/ServiceJsonRpcDescriptor`1.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServiceJsonRpcDescriptor`1.cs
@@ -18,9 +18,7 @@ public class ServiceJsonRpcDescriptor<T> : ServiceJsonRpcDescriptor
 	/// <param name="formatter">The formatter to use for the JSON-RPC message.</param>
 	/// <param name="messageDelimiter">The message delimiter scheme to use.</param>
 	public ServiceJsonRpcDescriptor(ServiceMoniker serviceMoniker, Formatters formatter, MessageDelimiters messageDelimiter)
-#pragma warning disable CS0618 // Type or member is obsolete. Support for legacy calls.
 		: base(serviceMoniker, formatter, messageDelimiter)
-#pragma warning restore CS0618 // Type or member is obsolete
 	{
 	}
 
@@ -32,9 +30,7 @@ public class ServiceJsonRpcDescriptor<T> : ServiceJsonRpcDescriptor
 	/// <param name="formatter">The formatter to use for the JSON-RPC message.</param>
 	/// <param name="messageDelimiter">The message delimiter scheme to use.</param>
 	public ServiceJsonRpcDescriptor(ServiceMoniker serviceMoniker, Type? clientInterface, Formatters formatter, MessageDelimiters messageDelimiter)
-#pragma warning disable CS0618 // Type or member is obsolete. Support for legacy calls.
 		: base(serviceMoniker, clientInterface, formatter, messageDelimiter)
-#pragma warning restore CS0618 // Type or member is obsolete
 	{
 	}
 

--- a/src/Microsoft.ServiceHub.Framework/Services/AuthorizationServiceClient.cs
+++ b/src/Microsoft.ServiceHub.Framework/Services/AuthorizationServiceClient.cs
@@ -3,8 +3,6 @@
 
 using Microsoft.VisualStudio.Threading;
 
-#pragma warning disable SA1009 // Closing parenthesis must be spaced correctly (StyleCop.Analyzers update required)
-
 namespace Microsoft.ServiceHub.Framework.Services;
 
 /// <summary>
@@ -33,9 +31,7 @@ public class AuthorizationServiceClient : IDisposableObservable
 	/// </summary>
 	/// <param name="authorizationService">The client proxy of the authorization service that this instance will wrap. This will be disposed (if it implements <see cref="IDisposable"/>) when this <see cref="AuthorizationServiceClient"/> is disposed.</param>
 	/// <param name="ownsAuthorizationService"><see langword="true"/> to dispose of <paramref name="authorizationService"/> when this instance is disposed; otherwise <see langword="false"/>.</param>
-#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 	public AuthorizationServiceClient(IAuthorizationService authorizationService, bool ownsAuthorizationService = true)
-#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 	{
 		this.AuthorizationService = authorizationService ?? throw new ArgumentNullException(nameof(authorizationService));
 		this.ownsAuthorizationService = ownsAuthorizationService;
@@ -53,9 +49,7 @@ public class AuthorizationServiceClient : IDisposableObservable
 	/// <param name="joinableTaskFactory">A means to avoid deadlocks if the authorization service requires the main thread. May be null.</param>
 	/// <param name="ownsAuthorizationService"><see langword="true"/> to dispose of <paramref name="authorizationService"/> when this instance is disposed; otherwise <see langword="false"/>.</param>
 	[Obsolete("Use the overload that does not accept a JoinableTaskFactory instead. This overload will be removed in a future release.", error: true)]
-#pragma warning disable RS0026 // Do not add multiple public overloads with optional parameters
 	public AuthorizationServiceClient(IAuthorizationService authorizationService, JoinableTaskFactory? joinableTaskFactory, bool ownsAuthorizationService = true)
-#pragma warning restore RS0026 // Do not add multiple public overloads with optional parameters
 		: this(authorizationService, ownsAuthorizationService)
 	{
 	}

--- a/src/Microsoft.ServiceHub.Framework/Services/IBrokeredServiceManifest.cs
+++ b/src/Microsoft.ServiceHub.Framework/Services/IBrokeredServiceManifest.cs
@@ -1,0 +1,36 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+
+namespace Microsoft.ServiceHub.Framework.Services;
+
+/// <summary>
+/// Exposes details about availability of services proffered to the client.
+/// Obtainable from the <see cref="FrameworkServices.RemoteBrokeredServiceManifest"/> service.
+/// </summary>
+/// <remarks>
+/// The results are based on the caller.
+/// For example if an instance of this service is obtained by a Live Share guest
+/// the results from method calls may vary from an instance of this service obtained by a Codespaces client.
+/// </remarks>
+public interface IBrokeredServiceManifest
+{
+	/// <summary>
+	/// Gets the list of services that are available from an <see cref="IServiceBroker"/>.
+	/// </summary>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>A collection of service monikers.</returns>
+	ValueTask<IReadOnlyCollection<ServiceMoniker>> GetAvailableServicesAsync(CancellationToken cancellationToken);
+
+	/// <summary>
+	/// Gets the collection of versions available for the specified service from an <see cref="IServiceBroker"/>.
+	/// </summary>
+	/// <param name="serviceName">The <see cref="ServiceMoniker.Name"/> from the <see cref="ServiceMoniker"/> for the service to get information about.</param>
+	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <returns>
+	/// A collection of versions available for the named service.
+	/// A null element may be in the collection if the server may consider a service request without regard to the requested version.
+	/// </returns>
+	ValueTask<ImmutableSortedSet<Version?>> GetAvailableVersionsAsync(string serviceName, CancellationToken cancellationToken);
+}

--- a/src/Microsoft.ServiceHub.Framework/Strings.Designer.cs
+++ b/src/Microsoft.ServiceHub.Framework/Strings.Designer.cs
@@ -70,6 +70,33 @@ namespace Microsoft.ServiceHub.Framework {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Failed to get the process id of the client..
+        /// </summary>
+        internal static string CouldNotGetProcessId {
+            get {
+                return ResourceManager.GetString("CouldNotGetProcessId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {0} &apos;{1}&apos; was not provided in the service request or it did not contain a valid PID..
+        /// </summary>
+        internal static string Error_InvalidExternalClientProcessPid {
+            get {
+                return ResourceManager.GetString("Error_InvalidExternalClientProcessPid", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Failed to validate the client connecting..
+        /// </summary>
+        internal static string FailedToValidateClient {
+            get {
+                return ResourceManager.GetString("FailedToValidateClient", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The formatter &quot;{0}&quot; is not supported for the protocol &quot;{1}&quot;..
         /// </summary>
         internal static string FormatterNotSupported {
@@ -84,6 +111,15 @@ namespace Microsoft.ServiceHub.Framework {
         internal static string MessageDelimiterNotSupported {
             get {
                 return ResourceManager.GetString("MessageDelimiterNotSupported", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Named pipe client could not be validated..
+        /// </summary>
+        internal static string NamedPipeClientCouldNotBeValidated {
+            get {
+                return ResourceManager.GetString("NamedPipeClientCouldNotBeValidated", resourceCulture);
             }
         }
         
@@ -111,6 +147,15 @@ namespace Microsoft.ServiceHub.Framework {
         internal static string ServiceActivationFailed {
             get {
                 return ResourceManager.GetString("ServiceActivationFailed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The service &quot;{0}&quot; has already been proffered. Dispose the result of the last proffered factory before proffering another one..
+        /// </summary>
+        internal static string ServiceMoniker_AlreadyProffered {
+            get {
+                return ResourceManager.GetString("ServiceMoniker_AlreadyProffered", resourceCulture);
             }
         }
         

--- a/src/Microsoft.ServiceHub.Framework/Strings.resx
+++ b/src/Microsoft.ServiceHub.Framework/Strings.resx
@@ -120,11 +120,24 @@
   <data name="ClientProxyTypeArgumentMustBeAnInterface" xml:space="preserve">
     <value>"{0}" is not an interface.</value>
   </data>
+  <data name="CouldNotGetProcessId" xml:space="preserve">
+    <value>Failed to get the process id of the client.</value>
+  </data>
+  <data name="Error_InvalidExternalClientProcessPid" xml:space="preserve">
+    <value>{0} '{1}' was not provided in the service request or it did not contain a valid PID.</value>
+    <comment>Error message when the PID of a remote process connecting to brokered service was not provided as a ServiceActivationOption. {0} is the type ServiceActivationOption, {1} is the name of option that was missing.</comment>
+  </data>
+  <data name="FailedToValidateClient" xml:space="preserve">
+    <value>Failed to validate the client connecting.</value>
+  </data>
   <data name="FormatterNotSupported" xml:space="preserve">
     <value>The formatter "{0}" is not supported for the protocol "{1}".</value>
   </data>
   <data name="MessageDelimiterNotSupported" xml:space="preserve">
     <value>The message delimiter scheme "{0}" is not supported for the protocol "{1}".</value>
+  </data>
+  <data name="NamedPipeClientCouldNotBeValidated" xml:space="preserve">
+    <value>Named pipe client could not be validated.</value>
   </data>
   <data name="NotInitialized" xml:space="preserve">
     <value>This instance has not been initialized.</value>
@@ -135,6 +148,9 @@
   <data name="ServiceActivationFailed" xml:space="preserve">
     <value>Activating the "{0}" service failed.</value>
     <comment>{0} is a placeholder for a service moniker.</comment>
+  </data>
+  <data name="ServiceMoniker_AlreadyProffered" xml:space="preserve">
+    <value>The service "{0}" has already been proffered. Dispose the result of the last proffered factory before proffering another one.</value>
   </data>
   <data name="TooManyServices" xml:space="preserve">
     <value>More than one service found for "{0}" but at most one was allowed.</value>

--- a/test/Microsoft.ServiceHub.Analyzers.Tests/Microsoft.ServiceHub.Analyzers.Tests.csproj
+++ b/test/Microsoft.ServiceHub.Analyzers.Tests/Microsoft.ServiceHub.Analyzers.Tests.csproj
@@ -14,6 +14,8 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" />
     <PackageReference Include="Microsoft.CodeAnalysis" />
+    <!-- Workaround https://github.com/dotnet/roslyn-sdk/issues/1053 by downgrading the VS-MEF version we deploy. -->
+    <PackageReference Include="Microsoft.VisualStudio.Composition" VersionOverride="16.1.8" />
     <PackageReference Include="NuGet.Protocol" />
   </ItemGroup>
 

--- a/test/Microsoft.ServiceHub.Framework.Testing.Tests/App.config
+++ b/test/Microsoft.ServiceHub.Framework.Testing.Tests/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+  <appSettings>
+    <add key="xunit.shadowCopy" value="false" />
+  </appSettings>
+</configuration>

--- a/test/Microsoft.ServiceHub.Framework.Testing.Tests/Microsoft.ServiceHub.Framework.Testing.Tests.csproj
+++ b/test/Microsoft.ServiceHub.Framework.Testing.Tests/Microsoft.ServiceHub.Framework.Testing.Tests.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net6.0</TargetFrameworks>
@@ -8,8 +8,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.ServiceHub.Framework.Testing\Microsoft.ServiceHub.Framework.Testing.csproj" />
-    <ProjectReference Include="..\..\src\Microsoft.ServiceHub.Framework\Microsoft.ServiceHub.Framework.csproj" />
-    <ProjectReference Include="..\ExternalTestAssembly\ExternalTestAssembly.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -18,11 +16,9 @@
     <PackageReference Include="Microsoft.VisualStudio.RpcContracts" ExcludeAssets="compile" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities" ExcludeAssets="compile" />
     <PackageReference Include="Microsoft.VisualStudio.Utilities.Testing" ExcludeAssets="compile" />
-    <PackageReference Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" />
     <PackageReference Include="Xunit.Combinatorial" />
     <PackageReference Include="xunit.runner.visualstudio" />
     <PackageReference Include="xunit" />
     <PackageReference Include="Xunit.SkippableFact" />
   </ItemGroup>
-
 </Project>

--- a/test/Microsoft.ServiceHub.Framework.Testing.Tests/MockBrokeredServiceContainerTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Testing.Tests/MockBrokeredServiceContainerTests.cs
@@ -1,0 +1,39 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.ServiceHub.Framework;
+using Microsoft.ServiceHub.Framework.Testing;
+using Xunit;
+
+public class MockBrokeredServiceContainerTests
+{
+	private static readonly ServiceRpcDescriptor Descriptor = new ServiceJsonRpcDescriptor(
+		new ServiceMoniker("TestService"),
+		ServiceJsonRpcDescriptor.Formatters.MessagePack,
+		ServiceJsonRpcDescriptor.MessageDelimiters.BigEndianInt32LengthHeader);
+
+	private interface IMockService
+	{
+	}
+
+	[Fact]
+	public async Task ProfferedServiceCanBeObtained()
+	{
+		var container = new MockBrokeredServiceContainer();
+		using IDisposable proffer = container.Proffer(Descriptor, (mk, options, sb, ct) => new(new MockService()));
+		IServiceBroker sb = container.GetFullAccessServiceBroker();
+		IMockService? proxy = await sb.GetProxyAsync<IMockService>(Descriptor);
+		try
+		{
+			Assert.NotNull(proxy);
+		}
+		finally
+		{
+			(proxy as IDisposable)?.Dispose();
+		}
+	}
+
+	private class MockService : IMockService
+	{
+	}
+}

--- a/test/Microsoft.ServiceHub.Framework.Tests/Container/BrokeredServiceContainerTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/Container/BrokeredServiceContainerTests.cs
@@ -1,0 +1,97 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.ServiceHub.Framework;
+using Microsoft.ServiceHub.Framework.Testing;
+using Xunit;
+
+public class BrokeredServiceContainerTests
+{
+	private static readonly ServiceRpcDescriptor Descriptor = new ServiceJsonRpcDescriptor(new ServiceMoniker("TestService"), ServiceJsonRpcDescriptor.Formatters.MessagePack, ServiceJsonRpcDescriptor.MessageDelimiters.BigEndianInt32LengthHeader);
+#pragma warning disable SA1310 // Field names should not contain underscore
+	private static readonly ServiceRpcDescriptor Descriptor1_0 = new ServiceJsonRpcDescriptor(new ServiceMoniker("TestService", new(1, 0)), ServiceJsonRpcDescriptor.Formatters.MessagePack, ServiceJsonRpcDescriptor.MessageDelimiters.BigEndianInt32LengthHeader);
+	private static readonly ServiceRpcDescriptor Descriptor1_1 = new ServiceJsonRpcDescriptor(new ServiceMoniker("TestService", new(1, 1)), ServiceJsonRpcDescriptor.Formatters.MessagePack, ServiceJsonRpcDescriptor.MessageDelimiters.BigEndianInt32LengthHeader);
+#pragma warning restore SA1310 // Field names should not contain underscore
+	private readonly MockBrokeredServiceContainer container = new MockBrokeredServiceContainer();
+	private IServiceBroker serviceBroker;
+
+	private ServiceMoniker? lastRequestedMoniker;
+
+	public BrokeredServiceContainerTests()
+	{
+		this.serviceBroker = this.container.GetFullAccessServiceBroker();
+	}
+
+	private interface IMockService : IDisposable
+	{
+	}
+
+	[Fact]
+	public async Task UnversionedRequestMatchesUnversionedService()
+	{
+		this.ProfferUnversionedService();
+		using (IMockService? proxy = await this.serviceBroker.GetProxyAsync<IMockService>(Descriptor))
+		{
+			Assert.NotNull(proxy);
+			Assert.Equal(Descriptor.Moniker, this.lastRequestedMoniker);
+		}
+	}
+
+	[Fact]
+	public async Task VersionedRequestMatchesUnversionedService()
+	{
+		this.ProfferUnversionedService();
+		using (IMockService? proxy = await this.serviceBroker.GetProxyAsync<IMockService>(Descriptor1_0))
+		{
+			Assert.NotNull(proxy);
+			Assert.Equal(Descriptor1_0.Moniker, this.lastRequestedMoniker);
+		}
+	}
+
+	[Fact]
+	public async Task VersionedRequestMatchesVersionedService()
+	{
+		this.ProfferVersionedService();
+		using (IMockService? proxy = await this.serviceBroker.GetProxyAsync<IMockService>(Descriptor1_0))
+		{
+			Assert.NotNull(proxy);
+			Assert.Equal(Descriptor1_0.Moniker, this.lastRequestedMoniker);
+		}
+	}
+
+	[Fact]
+	public async Task VersionedRequestDoesNotMatchMisversionedService()
+	{
+		this.ProfferVersionedService();
+		using (IMockService? proxy = await this.serviceBroker.GetProxyAsync<IMockService>(Descriptor1_1))
+		{
+			Assert.Null(proxy);
+			Assert.Null(this.lastRequestedMoniker);
+		}
+	}
+
+	private void ProfferUnversionedService()
+	{
+		this.container.Proffer(Descriptor, (mk, options, sb, ct) =>
+		{
+			this.lastRequestedMoniker = mk;
+			return new(new MockService());
+		});
+	}
+
+	private void ProfferVersionedService()
+	{
+		this.container.Proffer(Descriptor1_0, (mk, options, sb, ct) =>
+		{
+			this.lastRequestedMoniker = mk;
+			return new(new MockService());
+		});
+	}
+
+	private class MockService : IMockService
+	{
+		public void Dispose()
+		{
+		}
+	}
+}

--- a/test/Microsoft.ServiceHub.Framework.Tests/Container/ExportedBrokeredServiceTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/Container/ExportedBrokeredServiceTests.cs
@@ -1,0 +1,216 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.ComponentModel.Composition;
+using Microsoft;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.ServiceHub.Framework.Services;
+using Microsoft.ServiceHub.Framework.Testing;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+using Xunit;
+using Xunit.Abstractions;
+
+public class ExportedBrokeredServiceTests : TestBase, IAsyncLifetime
+{
+	private MockBrokeredServiceContainer container = new MockBrokeredServiceContainer();
+
+	public ExportedBrokeredServiceTests(ITestOutputHelper logger)
+		: base(logger)
+	{
+	}
+
+	private interface ICalculator
+	{
+		ValueTask<MockService> GetThisAsync();
+
+		ValueTask<int> AddAsync(int a, int b);
+	}
+
+	private IServiceBroker ServiceBroker => this.container.GetFullAccessServiceBroker();
+
+	public async Task InitializeAsync()
+	{
+		MefHost mefHost = new MefHost
+		{
+			BrokeredServiceContainer = this.container,
+		};
+
+		// This has a side effect of registering MEF exported brokered services into the mock container.
+		await mefHost.CreateExportProviderAsync();
+	}
+
+	public Task DisposeAsync()
+	{
+		return Task.CompletedTask;
+	}
+
+	[Fact]
+	public async Task InvokeBrokeredService()
+	{
+		ICalculator? calc = await this.ServiceBroker.GetProxyAsync<ICalculator>(MockService.SharedDescriptor);
+		using (calc as IDisposable)
+		{
+			Assumes.Present(calc);
+			Assert.Equal(5, await calc.AddAsync(2, 3));
+		}
+	}
+
+	[Fact]
+	public async Task ImportsAreSatisfied()
+	{
+		ServiceActivationOptions options = new()
+		{
+			ActivationArguments = new Dictionary<string, string>
+				{
+					{ "a", "b" },
+				},
+		};
+		ICalculator? calc = await this.ServiceBroker.GetProxyAsync<ICalculator>(MockServiceWithImports.SharedDescriptor, options);
+		using (calc as IDisposable)
+		{
+			Assumes.Present(calc);
+			MockServiceWithImports realObject = (MockServiceWithImports)await calc.GetThisAsync();
+			Assert.Equal(MockServiceWithImports.SharedDescriptor.Moniker, realObject.ServiceMoniker);
+			Assert.NotNull(realObject.AuthorizationServiceClient);
+			Assert.NotNull(realObject.ServiceBroker);
+			Assert.Equal(options.ActivationArguments["a"], realObject.ServiceActivationOptions.ActivationArguments?["a"]);
+		}
+	}
+
+	[Fact]
+	public async Task BrokeredServiceIsInitialized()
+	{
+		ICalculator? calc = await this.ServiceBroker.GetProxyAsync<ICalculator>(MockService.SharedDescriptor);
+		MockService realObject;
+		using (calc as IDisposable)
+		{
+			Assumes.Present(calc);
+			realObject = await calc.GetThisAsync();
+			Assert.Equal(1, realObject.InitializeInvocationCount);
+		}
+
+		Assert.Equal(1, realObject.InitializeInvocationCount);
+	}
+
+	[Fact]
+	public async Task BrokeredServiceIsDisposed()
+	{
+		ICalculator? calc = await this.ServiceBroker.GetProxyAsync<ICalculator>(MockService.SharedDescriptor);
+		MockService realObject;
+		using (calc as IDisposable)
+		{
+			Assumes.Present(calc);
+			realObject = await calc.GetThisAsync();
+			Assert.Equal(0, realObject.DisposalInvocationCount);
+		}
+
+		// It's a known issue that MEF exported brokered services get disposed twice.
+		// If that is ever corrected, change this to assert 1.
+		Assert.Equal(2, realObject.DisposalInvocationCount);
+	}
+
+	[Fact]
+	public async Task BrokeredServiceWithImportsIsDisposed()
+	{
+		ICalculator? calc = await this.ServiceBroker.GetProxyAsync<ICalculator>(MockServiceWithImports.SharedDescriptor);
+		MockService realObject;
+		using (calc as IDisposable)
+		{
+			Assumes.Present(calc);
+			realObject = await calc.GetThisAsync();
+			Assert.Equal(0, realObject.DisposalInvocationCount);
+		}
+
+		// It's a known issue that MEF exported brokered services get disposed twice.
+		// If that is ever corrected, change this to assert 1.
+		Assert.Equal(2, realObject.DisposalInvocationCount);
+	}
+
+	/// <summary>
+	/// Verifies that a MEFv1 exported brokered service is created as a non-shared part,
+	/// even if not explicitly attributed as such.
+	/// </summary>
+	[Fact]
+	public async Task BrokeredServiceWithoutImportsIsNonShared()
+	{
+		MockService realObject1, realObject2;
+		ICalculator? calc = await this.ServiceBroker.GetProxyAsync<ICalculator>(MockService.SharedDescriptor);
+		using (calc as IDisposable)
+		{
+			Assumes.Present(calc);
+			realObject1 = await calc.GetThisAsync();
+		}
+
+		calc = await this.ServiceBroker.GetProxyAsync<ICalculator>(MockService.SharedDescriptor);
+		using (calc as IDisposable)
+		{
+			Assumes.Present(calc);
+			realObject2 = await calc.GetThisAsync();
+		}
+
+		Assert.NotSame(realObject1, realObject2);
+	}
+
+	[ExportBrokeredService("Calculator", "1.0")]
+	private class MockService : IExportedBrokeredService, ICalculator, IDisposable
+	{
+		internal static readonly ServiceRpcDescriptor SharedDescriptor = new ServiceJsonRpcDescriptor(
+			new ServiceMoniker("Calculator", new Version("1.0")),
+			clientInterface: null,
+			ServiceJsonRpcDescriptor.Formatters.MessagePack,
+			ServiceJsonRpcDescriptor.MessageDelimiters.BigEndianInt32LengthHeader,
+			new Nerdbank.Streams.MultiplexingStream.Options
+			{
+				ProtocolMajorVersion = 3,
+			});
+
+		public virtual ServiceRpcDescriptor Descriptor => SharedDescriptor;
+
+		internal int InitializeInvocationCount { get; private set; }
+
+		internal int DisposalInvocationCount { get; private set; }
+
+		public ValueTask<MockService> GetThisAsync() => new(this);
+
+		public ValueTask<int> AddAsync(int a, int b) => new(a + b);
+
+		public Task InitializeAsync(CancellationToken cancellationToken)
+		{
+			this.InitializeInvocationCount++;
+			return Task.CompletedTask;
+		}
+
+		public void Dispose()
+		{
+			this.DisposalInvocationCount++;
+		}
+	}
+
+	[ExportBrokeredService("Calculator", "1.1")]
+	private class MockServiceWithImports : MockService
+	{
+		internal static readonly new ServiceRpcDescriptor SharedDescriptor = new ServiceJsonRpcDescriptor(
+			new ServiceMoniker("Calculator", new Version("1.1")),
+			clientInterface: null,
+			ServiceJsonRpcDescriptor.Formatters.MessagePack,
+			ServiceJsonRpcDescriptor.MessageDelimiters.BigEndianInt32LengthHeader,
+			new Nerdbank.Streams.MultiplexingStream.Options
+			{
+				ProtocolMajorVersion = 3,
+			});
+
+		public override ServiceRpcDescriptor Descriptor => SharedDescriptor;
+
+		[Import]
+		internal ServiceMoniker ServiceMoniker { get; set; } = null!;
+
+		[Import]
+		internal ServiceActivationOptions ServiceActivationOptions { get; set; }
+
+		[Import]
+		internal IServiceBroker ServiceBroker { get; set; } = null!;
+
+		[Import]
+		internal AuthorizationServiceClient AuthorizationServiceClient { get; set; } = null!;
+	}
+}

--- a/test/Microsoft.ServiceHub.Framework.Tests/IpcPipeRelayServiceBrokerTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/IpcPipeRelayServiceBrokerTests.cs
@@ -3,7 +3,6 @@
 
 using System.Collections.Immutable;
 using System.IO.Pipes;
-using System.Runtime.Versioning;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Threading;
 using Xunit;

--- a/test/Microsoft.ServiceHub.Framework.Tests/Mocks/BrokeredServiceManifestMock.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/Mocks/BrokeredServiceManifestMock.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.ServiceHub.Framework.Services;
+
+public class BrokeredServiceManifestMock : IBrokeredServiceManifest
+{
+	internal static readonly IReadOnlyCollection<ServiceMoniker> GetAvailableServicesExpectedResult = ImmutableList.Create(
+		new ServiceMoniker("Calc", new Version(1, 0)),
+		new ServiceMoniker("Calc", new Version(1, 1)),
+		new ServiceMoniker("Prod"));
+
+	internal static readonly ImmutableSortedSet<Version?> GetAvailableVersionsExpectedResult = ImmutableSortedSet.Create(
+		new Version(1, 0),
+		new Version(1, 2, 3, 4),
+		null);
+
+	public ValueTask<IReadOnlyCollection<ServiceMoniker>> GetAvailableServicesAsync(CancellationToken cancellationToken)
+	{
+		return new ValueTask<IReadOnlyCollection<ServiceMoniker>>(GetAvailableServicesExpectedResult);
+	}
+
+	public ValueTask<ImmutableSortedSet<Version?>> GetAvailableVersionsAsync(string serviceName, CancellationToken cancellationToken)
+	{
+		return new ValueTask<ImmutableSortedSet<Version?>>(GetAvailableVersionsExpectedResult);
+	}
+}

--- a/test/Microsoft.ServiceHub.Framework.Tests/Mocks/MefHost.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/Mocks/MefHost.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Reflection;
+using Microsoft.VisualStudio.Composition;
+using Microsoft.VisualStudio.Threading;
+using Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+internal class MefHost
+{
+	private static readonly AsyncLazy<IExportProviderFactory> ExportProviderFactory = new(() => CreateExportProviderFactoryAsync(CancellationToken.None), null);
+
+	internal GlobalBrokeredServiceContainer? BrokeredServiceContainer { get; set; }
+
+	internal async ValueTask<ExportProvider> CreateExportProviderAsync(CancellationToken cancellationToken = default)
+	{
+		IExportProviderFactory exportProviderFactory = await ExportProviderFactory.GetValueAsync(cancellationToken);
+		ExportProvider exportProvider = exportProviderFactory.CreateExportProvider();
+
+		// Bootstrap brokered services
+		if (this.BrokeredServiceContainer is object)
+		{
+			MockServiceBrokerOfExportedServices mockBrokeredServices = exportProvider.GetExportedValue<MockServiceBrokerOfExportedServices>();
+			mockBrokeredServices.Container = this.BrokeredServiceContainer;
+			await mockBrokeredServices.RegisterAndProfferServicesAsync(cancellationToken);
+		}
+
+		return exportProvider;
+	}
+
+	private static async Task<IExportProviderFactory> CreateExportProviderFactoryAsync(CancellationToken cancellationToken)
+	{
+		PartDiscovery discovery = PartDiscovery.Combine(
+			new AttributedPartDiscovery(Resolver.DefaultInstance, isNonPublicSupported: true),
+			new AttributedPartDiscoveryV1(Resolver.DefaultInstance));
+		Assembly[] catalogAssemblies = new[]
+		{
+			typeof(GlobalBrokeredServiceContainer).Assembly,
+			typeof(MefHost).Assembly,
+		};
+		DiscoveredParts parts = await discovery.CreatePartsAsync(catalogAssemblies, cancellationToken: cancellationToken);
+		ComposableCatalog catalog = ComposableCatalog.Create(Resolver.DefaultInstance).AddParts(parts);
+		CompositionConfiguration configuration = CompositionConfiguration.Create(catalog);
+		configuration.ThrowOnErrors();
+		return configuration.CreateExportProviderFactory();
+	}
+}

--- a/test/Microsoft.ServiceHub.Framework.Tests/Mocks/MockServiceBrokerOfExportedServices.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/Mocks/MockServiceBrokerOfExportedServices.cs
@@ -1,0 +1,19 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Composition;
+using Microsoft;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+using Microsoft.VisualStudio.Utilities.ServiceBroker;
+
+[Export]
+internal class MockServiceBrokerOfExportedServices : ServiceBrokerOfExportedServices
+{
+	internal GlobalBrokeredServiceContainer? Container { get; set; }
+
+	protected override Task<GlobalBrokeredServiceContainer> GetBrokeredServiceContainerAsync(CancellationToken cancellationToken)
+	{
+		Verify.Operation(this.Container is object, "The container hasn't been set in the test yet.");
+		return Task.FromResult(this.Container);
+	}
+}

--- a/test/Microsoft.ServiceHub.Framework.Tests/Services/BrokeredServiceManifestTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/Services/BrokeredServiceManifestTests.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Collections.Immutable;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.ServiceHub.Framework.Services;
+using Microsoft.VisualStudio.Sdk.TestFramework;
+using Xunit;
+using Xunit.Abstractions;
+
+public class BrokeredServiceManifestTests : BrokeredServiceContractTestBase<IBrokeredServiceManifest, BrokeredServiceManifestMock>
+{
+	public BrokeredServiceManifestTests(ITestOutputHelper logger)
+		: base(logger, FrameworkServices.RemoteBrokeredServiceManifest)
+	{
+	}
+
+	[Fact]
+	public async Task GetAvailableServicesAsync()
+	{
+		IReadOnlyCollection<ServiceMoniker> result = await this.ClientProxy.GetAvailableServicesAsync(this.TimeoutToken);
+		Assert.Equal(BrokeredServiceManifestMock.GetAvailableServicesExpectedResult, result);
+	}
+
+	[Fact]
+	public async Task GetAvailableVersionsAsync()
+	{
+		ImmutableSortedSet<Version?> result = await this.ClientProxy.GetAvailableVersionsAsync("someService", this.TimeoutToken);
+		Assert.Equal(BrokeredServiceManifestMock.GetAvailableVersionsExpectedResult, result);
+		Assert.Contains(null, result);
+	}
+}


### PR DESCRIPTION
This adds all the classes and test support necessary for hosting brokered services in your own container for .NET processes.
The node.js equivalent will come later.

This brings in code from VS.RPC.Contracts, MS.VS.Utilities, MS.VS.Utilities.Testing, and vssdktestfx.