### PR TITLE
Partial pipe name protocol change rollback

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/IpcServer.cs
+++ b/src/Microsoft.ServiceHub.Framework/IpcServer.cs
@@ -25,7 +25,9 @@ internal class IpcServer : IDisposable, IIpcServer
 	{
 		if (options.Name is null)
 		{
-			options = options with { Name = ServerFactory.PrependPipePrefix(Guid.NewGuid().ToString("n")) };
+			// TEMPORARY: strip the \\.\pipe\ prefix from Windows pipe names to match the old IRemoteServiceBroker contract
+			// till we get all consumers updated to the new Microsoft.ServiceHub.Framework assembly which can handle that prefix.
+			options = options with { Name = ServerFactory.TrimWindowsPrefixForDotNet(ServerFactory.PrependPipePrefix(Guid.NewGuid().ToString("n"))) };
 		}
 		else
 		{


### PR DESCRIPTION
- Omit the pipe name prefix for remote services on Windows

  Although its arguably a good thing to fully-qualify all pipe names, older Microsoft.ServiceHub.Framework builds assumed the prefix on Windows would not be included in the `IRemoteServiceBroker`-returned pipe name and fail when it is included.

  To help us migrate to a fully-qualified world, the new code can *consume* Windows pipe names with or without the prefix. And for the short term this change rolls back the behavior of what is returned to once again omit the prefix (only on Windows) so that older clients won't fail.

  When all the clients have upgraded, we should revert this particular commit and return fully-qualified pipe names all the time.

- Accommodate Windows pipe names w/o prefix

  The NPM package required the `\\.\pipe\` prefix to be returned by an `IRemoteServiceBroker` to connect to a pipe on Windows. Most `IRemoteServiceBroker` implementations in use today do not include this prefix. While the prefix is arguably a good thing to include, we should accommodate them when they don't include it.