### PR TITLE
Drop `.Extensions` from namespace for the `ServiceManagerReflectionHelpers` class

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/Extensions/ServiceManagerReflectionHelpers.cs
+++ b/src/Microsoft.ServiceHub.Framework/Extensions/ServiceManagerReflectionHelpers.cs
@@ -6,7 +6,7 @@ using Microsoft.ServiceHub.Framework.Services;
 using Nerdbank.Streams;
 using Newtonsoft.Json;
 
-namespace Microsoft.ServiceHub.Framework.Extensions;
+namespace Microsoft.ServiceHub.Framework;
 
 /// <summary>
 /// Extension methods used via reflection in Microsoft.ServiceHub.HostStub.IServiceManager inside of the DevCore repository inside of Visual Studio.


### PR DESCRIPTION
This will be a breaking change to the new HostStub, but by accommodating it, HostStub will (once again) be compatible with both old and new SH.Framework assemblies. 