### PR TITLE
Remove VS-MEF downgrade workaround

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <MicroBuildVersion>2.0.107</MicroBuildVersion>
     <CodeAnalysisVersionForAnalyzers>3.11.0</CodeAnalysisVersionForAnalyzers>
     <CodeAnalysisVersion>4.4.0</CodeAnalysisVersion>
-    <CodefixTestingVersion>1.1.1</CodefixTestingVersion>
+    <CodefixTestingVersion>1.1.2-beta1.23110.2</CodefixTestingVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="IsExternalInit" Version="1.0.3" />

--- a/test/Microsoft.ServiceHub.Analyzers.Tests/Microsoft.ServiceHub.Analyzers.Tests.csproj
+++ b/test/Microsoft.ServiceHub.Analyzers.Tests/Microsoft.ServiceHub.Analyzers.Tests.csproj
@@ -14,8 +14,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" />
     <PackageReference Include="Microsoft.CodeAnalysis" />
-    <!-- Workaround https://github.com/dotnet/roslyn-sdk/issues/1053 by downgrading the VS-MEF version we deploy. -->
-    <PackageReference Include="Microsoft.VisualStudio.Composition" VersionOverride="16.1.8" NoWarn="NU1605" />
     <PackageReference Include="NuGet.Protocol" />
   </ItemGroup>
 


### PR DESCRIPTION
The roslyn analyzer test framework has resolved the VS-MEF issue on their end.