### PR TITLE
Fix args in notifications raised by javascript

### DIFF
--- a/src/servicebroker-npm/test/remoteServiceBrokerTests.ts
+++ b/src/servicebroker-npm/test/remoteServiceBrokerTests.ts
@@ -46,6 +46,13 @@ describe('Service Broker tests', function () {
 	// Sometimes, the first time we start ServiceBrokerTest.exe it hangs and the test throws a CancellationError
 	// We need to catch this error and close our connection to avoid tests not finishing
 	describe('Tests that start service broker exe', function () {
+		jest.setTimeout(15000)
+
+		beforeEach(() => {
+			defaultTokenSource = CancellationToken.timeout(15000)
+			defaultToken = defaultTokenSource.token
+		})
+
 		it('Should be able to query proxy server', async function () {
 			let mx: MultiplexingStream | null = null
 			try {

--- a/src/servicebroker-npm/test/testAssets/appleTreeService.ts
+++ b/src/servicebroker-npm/test/testAssets/appleTreeService.ts
@@ -1,4 +1,4 @@
-import { AppleGrownEventArgs, ApplePickedEventArgs, AppleTreeEmitter, IAppleTreeService } from './interfaces'
+import { ApplePickedEventArgs, AppleTreeEmitter, IAppleTreeService } from './interfaces'
 import { EventEmitter } from 'events'
 import CancellationToken from 'cancellationtoken'
 import { RpcEventServer } from '../../src/ServiceRpcDescriptor'
@@ -10,8 +10,8 @@ export class AppleTree extends (EventEmitter as new () => AppleTreeEmitter) impl
 		this.emit('picked', args)
 		return Promise.resolve()
 	}
-	grow(args: AppleGrownEventArgs, cancellationToken?: CancellationToken): Promise<void> {
-		this.emit('grown', args)
+	grow(seeds: number, weight: number, cancellationToken?: CancellationToken): Promise<void> {
+		this.emit('grown', seeds, weight)
 		return Promise.resolve()
 	}
 }

--- a/src/servicebroker-npm/test/testAssets/interfaces.ts
+++ b/src/servicebroker-npm/test/testAssets/interfaces.ts
@@ -31,20 +31,19 @@ export interface IWaitToBeCanceled {
 
 export interface ApplePickedEventArgs {
 	color: 'red' | 'green' | 'yellow'
-}
-
-export interface AppleGrownEventArgs {
-	seeds: number
+	weight: number
 }
 
 export interface AppleTreeEvents {
+	/** An event with one argument that contains two properties. */
 	picked: (args: ApplePickedEventArgs) => void
-	grown: (args: AppleGrownEventArgs) => void
+	/** An event with two arguments. */
+	grown: (seeds: number, weight: number) => void
 }
 
 export type AppleTreeEmitter = StrictEventEmitter<EventEmitter, AppleTreeEvents>
 
 export interface IAppleTreeService extends AppleTreeEmitter {
 	pick(args: ApplePickedEventArgs, cancellationToken?: CancellationToken): Promise<void>
-	grow(args: AppleGrownEventArgs, cancellationToken?: CancellationToken): Promise<void>
+	grow(seeds: number, weight: number, cancellationToken?: CancellationToken): Promise<void>
 }


### PR DESCRIPTION
A single argument to a notification was being serialized as the entire JSON-RPC `params` value, which per the protocol meant instead of one positional argument, we were sending the argument's properties each as their own named argument.
With this fix, we more carefully work with the vscode-jsonrpc library to ensure the arguments are always retained by the protocol as they were intended.

Use case:

```ts
const args = { seeds: 5, weight: 8 }
this.emit('picked', args)
```

This *was* being transmitted as:

```json
{
	"method": "picked",
	"params": {
		"seeds": 5,
		"weight": 8
	}
}
```

Note how the `args` object itself is directly used as the value for `params`, so this is interpreted by the protocol as two named arguments.
With the fix, it is now being transmitted as:

```json
{
	"method": "picked",
	"params": [
		{
			"seeds": 5,
			"weight": 8
		}
	]
}
```

Note the surrounding array, which means we're using *positional* arguments.
There is only one argument, which has two properties.
This now accurately represents what was actually done in the event raising code and means that a receiver can now dispatch to a method that was expecting the same signature (one arg, two properties).