### PR TITLE
Add CurrentUserOnly flag support to ServerFactory on .NET Framework

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/IpcServer.cs
+++ b/src/Microsoft.ServiceHub.Framework/IpcServer.cs
@@ -3,6 +3,8 @@
 
 using System.Diagnostics;
 using System.IO.Pipes;
+using System.Security.AccessControl;
+using System.Security.Principal;
 using Microsoft.VisualStudio.Threading;
 
 namespace Microsoft.ServiceHub.Framework;
@@ -183,12 +185,53 @@ internal class IpcServer : IDisposable, IIpcServer
 			// behavior is a named pipe specific behavior. Unix domain sockets cannot emulate it, so if any service or client were to
 			// depend on the message boundaries that named pipes offered, they might malfunction on *nix platforms.
 			// So instead, we simply don't offer that unique behavior.
+			PipeTransmissionMode transmissionMode = PipeTransmissionMode.Byte;
+
+			int maxNumberOfServerInstances = NamedPipeServerStream.MaxAllowedServerInstances;
+
+			PipeOptions pipeOptions = this.Options.PipeOptions;
+#if NETFRAMEWORK
+			// On .NET Framework, we have to implement the CurrentUserOnly security ourselves.
+			// https://github.com/dotnet/runtime/blob/220437ef6591bee5907ed097b5e193a1d1235dca/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs#L98-L119
+			PipeSecurity? pipeSecurity = null;
+			if ((pipeOptions & PolyfillExtensions.PipeOptionsCurrentUserOnly) == PolyfillExtensions.PipeOptionsCurrentUserOnly)
+			{
+				pipeSecurity = new PipeSecurity();
+				using (WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent())
+				{
+					SecurityIdentifier identifier = currentIdentity.Owner!;
+
+					// Grant full control to the owner so multiple servers can be opened.
+					// Full control is the default per MSDN docs for CreateNamedPipe.
+					PipeAccessRule rule = new PipeAccessRule(identifier, PipeAccessRights.FullControl, AccessControlType.Allow);
+
+					pipeSecurity.AddAccessRule(rule);
+					pipeSecurity.SetOwner(identifier);
+				}
+
+				// PipeOptions.CurrentUserOnly is special since it doesn't match directly to a corresponding Win32 valid flag.
+				// Remove it, while keeping others untouched since historically this has been used as a way to pass flags to CreateNamedPipe
+				// that were not defined in the enumeration.
+				pipeOptions &= ~PolyfillExtensions.PipeOptionsCurrentUserOnly;
+			}
+
 			return new NamedPipeServerStream(
 				channelName,
 				PipeDirection.InOut,
-				NamedPipeServerStream.MaxAllowedServerInstances,
-				PipeTransmissionMode.Byte,
-				this.Options.PipeOptions);
+				maxNumberOfServerInstances,
+				transmissionMode,
+				pipeOptions,
+				inBufferSize: 0,
+				outBufferSize: 0,
+				pipeSecurity);
+#else
+			return new NamedPipeServerStream(
+				channelName,
+				PipeDirection.InOut,
+				maxNumberOfServerInstances,
+				transmissionMode,
+				pipeOptions);
+#endif
 		}
 
 		async Task ClientConnectedAsync(PipeStream stream)

--- a/src/Microsoft.ServiceHub.Framework/Microsoft.ServiceHub.Framework.csproj
+++ b/src/Microsoft.ServiceHub.Framework/Microsoft.ServiceHub.Framework.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0;net472</TargetFrameworks>
     <Description>The distributed ServiceHub Framework.</Description>
   </PropertyGroup>
 

--- a/src/Microsoft.ServiceHub.Framework/PolyfillExtensions.cs
+++ b/src/Microsoft.ServiceHub.Framework/PolyfillExtensions.cs
@@ -4,6 +4,8 @@
 #pragma warning disable SA1402 // File may only contain a single type
 #pragma warning disable SA1403 // File may only contain a single namespace
 
+using System.IO.Pipes;
+
 namespace Microsoft.ServiceHub.Framework
 {
 	/// <summary>
@@ -12,6 +14,21 @@ namespace Microsoft.ServiceHub.Framework
 	internal static class PolyfillExtensions
 	{
 #if !NET5_0_OR_GREATER
+		/// <summary>
+		/// When used to create a <see cref="NamedPipeServerStream"/> instance, indicates
+		/// that the pipe can only be connected to a client created by the same user. When
+		/// used to create a <see cref="NamedPipeClientStream"/> instance, indicates that
+		/// the pipe can only connect to a server created by the same user. On Windows, it
+		/// verifies both the user account and elevation level.
+		/// </summary>
+		/// <remarks>
+		/// .NET implements this, but on .NET Framework we have to implement it ourselves.
+		/// .NET's implementations are available as a template for us to follow:
+		/// <see href="https://github.com/dotnet/runtime/blob/220437ef6591bee5907ed097b5e193a1d1235dca/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeServerStream.Windows.cs#L102-L113">server</see> and
+		/// <see href="https://github.com/dotnet/runtime/blob/220437ef6591bee5907ed097b5e193a1d1235dca/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs#L141-L151">client</see>.
+		/// </remarks>
+		internal const PipeOptions PipeOptionsCurrentUserOnly = (PipeOptions)0x2000_0000;
+
 		/// <summary>
 		/// Disposes the stream.
 		/// </summary>

--- a/src/Microsoft.ServiceHub.Framework/ServerFactory.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServerFactory.cs
@@ -5,6 +5,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics;
 using System.IO.Pipes;
 using System.Runtime.InteropServices;
+using System.Security.Principal;
 using Windows.Win32.Foundation;
 using static Windows.Win32.PInvoke;
 
@@ -21,7 +22,7 @@ public static class ServerFactory
 #if NET5_0_OR_GREATER
 	internal const PipeOptions StandardPipeOptions = PipeOptions.Asynchronous | PipeOptions.CurrentUserOnly;
 #else
-	internal const PipeOptions StandardPipeOptions = PipeOptions.Asynchronous;
+	internal const PipeOptions StandardPipeOptions = PipeOptions.Asynchronous | PolyfillExtensions.PipeOptionsCurrentUserOnly;
 #endif
 
 	private const int ConnectRetryIntervalMs = 20;
@@ -86,10 +87,20 @@ public static class ServerFactory
 	{
 		Requires.NotNull(pipeName, nameof(pipeName));
 
-		NamedPipeClientStream pipeStream = new(".", TrimWindowsPrefixForDotNet(pipeName), PipeDirection.InOut, StandardPipeOptions);
+		PipeOptions fullPipeOptions = StandardPipeOptions;
+		PipeOptions pipeOptions = StandardPipeOptions;
+
+#if NETFRAMEWORK
+		// PipeOptions.CurrentUserOnly is special since it doesn't match directly to a corresponding Win32 valid flag.
+		// Remove it, while keeping others untouched since historically this has been used as a way to pass flags to CreateNamedPipe
+		// that were not defined in the enumeration.
+		pipeOptions &= ~PolyfillExtensions.PipeOptionsCurrentUserOnly;
+#endif
+
+		NamedPipeClientStream pipeStream = new(".", TrimWindowsPrefixForDotNet(pipeName), PipeDirection.InOut, pipeOptions);
 		try
 		{
-			await ConnectWithRetryAsync(pipeStream, cancellationToken, maxRetries: options.FailFast ? 0 : int.MaxValue, withSpinningWait: options.CpuSpinOverFirstChanceExceptions).ConfigureAwait(false);
+			await ConnectWithRetryAsync(pipeStream, fullPipeOptions, cancellationToken, maxRetries: options.FailFast ? 0 : int.MaxValue, withSpinningWait: options.CpuSpinOverFirstChanceExceptions).ConfigureAwait(false);
 			return pipeStream;
 		}
 		catch
@@ -128,12 +139,13 @@ public static class ServerFactory
 	/// Connects to a named pipe without spinning the CPU as <see cref="NamedPipeClientStream.Connect(int)"/> or <see cref="NamedPipeClientStream.ConnectAsync(CancellationToken)"/> would do.
 	/// </summary>
 	/// <param name="npcs">The named pipe client stream to connect.</param>
+	/// <param name="pipeOptions">The pipe options applied to this connection.</param>
 	/// <param name="cancellationToken">A cancellation token.</param>
 	/// <param name="maxRetries">The maximum number of retries to attempt.</param>
 	/// <param name="withSpinningWait">Whether or not the connect should be attempted with a spinning wait.
 	/// If the pipe being connected to is known to exist, it is safe to use a spinning wait to avoid potentially throwing exceptions for retries.</param>
 	/// <returns>A <see cref="Task"/> that tracks the asynchronous connection attempt.</returns>
-	private static async Task ConnectWithRetryAsync(NamedPipeClientStream npcs, CancellationToken cancellationToken, int maxRetries = int.MaxValue, bool withSpinningWait = false)
+	private static async Task ConnectWithRetryAsync(NamedPipeClientStream npcs, PipeOptions pipeOptions, CancellationToken cancellationToken, int maxRetries = int.MaxValue, bool withSpinningWait = false)
 	{
 		Requires.NotNull(npcs, nameof(npcs));
 
@@ -156,6 +168,9 @@ public static class ServerFactory
 					await npcs.ConnectAsync((int)NMPWAIT_NOWAIT).ConfigureAwait(false);
 				}
 
+#if NETFRAMEWORK
+				ValidateRemotePipeUser(npcs, pipeOptions);
+#endif
 				return;
 			}
 			catch (Exception ex)
@@ -198,6 +213,31 @@ public static class ServerFactory
 			}
 		}
 	}
+
+#if NETFRAMEWORK
+	/// <remarks>
+	/// Source code for this came from <see href="https://github.com/dotnet/runtime/blob/220437ef6591bee5907ed097b5e193a1d1235dca/src/libraries/System.IO.Pipes/src/System/IO/Pipes/NamedPipeClientStream.Windows.cs#LL136C8-L152C10">.NET source code</see>.
+	/// </remarks>
+	private static void ValidateRemotePipeUser(NamedPipeClientStream clientStream, PipeOptions pipeOptions)
+	{
+		if ((pipeOptions & PolyfillExtensions.PipeOptionsCurrentUserOnly) != PolyfillExtensions.PipeOptionsCurrentUserOnly)
+		{
+			return;
+		}
+
+		PipeSecurity accessControl = clientStream.GetAccessControl();
+		IdentityReference? remoteOwnerSid = accessControl.GetOwner(typeof(SecurityIdentifier));
+		using (WindowsIdentity currentIdentity = WindowsIdentity.GetCurrent())
+		{
+			SecurityIdentifier? currentUserSid = currentIdentity.Owner;
+			if (remoteOwnerSid != currentUserSid)
+			{
+				clientStream.Close();
+				throw new UnauthorizedAccessException(Strings.PipeNotOwnedByCurrentUser);
+			}
+		}
+	}
+#endif
 
 	/// <summary>
 	/// Options that can influence the IPC server.

--- a/src/Microsoft.ServiceHub.Framework/Strings.Designer.cs
+++ b/src/Microsoft.ServiceHub.Framework/Strings.Designer.cs
@@ -133,6 +133,15 @@ namespace Microsoft.ServiceHub.Framework {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This pipe is not owned by the current user..
+        /// </summary>
+        internal static string PipeNotOwnedByCurrentUser {
+            get {
+                return ResourceManager.GetString("PipeNotOwnedByCurrentUser", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The protocol &quot;{0}&quot; is not supported..
         /// </summary>
         internal static string ProtocolNotSupported {

--- a/src/Microsoft.ServiceHub.Framework/Strings.resx
+++ b/src/Microsoft.ServiceHub.Framework/Strings.resx
@@ -142,6 +142,9 @@
   <data name="NotInitialized" xml:space="preserve">
     <value>This instance has not been initialized.</value>
   </data>
+  <data name="PipeNotOwnedByCurrentUser" xml:space="preserve">
+    <value>This pipe is not owned by the current user.</value>
+  </data>
   <data name="ProtocolNotSupported" xml:space="preserve">
     <value>The protocol "{0}" is not supported.</value>
   </data>


### PR DESCRIPTION
This makes named pipes set up on .NET Framework as safe as on .NET.

There are two sides to this: 
1. The server, which can ACL its own pipe to ensure its security.
2. The client, which has to connect to the pipe first and then check the ACL in order to verify it is owned by a server with the expected ACLs.