### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -7,6 +7,9 @@
 *.sh eol=lf
 *.ps1 eol=lf
 
+# The macOS codesign tool is extremely picky, and requires LF line endings.
+*.plist eol=lf
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -11,7 +11,8 @@
     "davidanson.vscode-markdownlint",
     "dotjoshjohnson.xml",
     "ms-vscode-remote.remote-containers",
-    "ms-azuretools.vscode-docker"
+    "ms-azuretools.vscode-docker",
+    "tintoy.msbuild-project-tools"
   ],
   // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
   "unwantedRecommendations": []

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicroBuildVersion>2.0.113</MicroBuildVersion>
+    <MicroBuildVersion>2.0.115</MicroBuildVersion>
     <CodeAnalysisVersionForAnalyzers>3.11.0</CodeAnalysisVersionForAnalyzers>
     <CodeAnalysisVersion>4.4.0</CodeAnalysisVersion>
     <CodefixTestingVersion>1.1.2-beta1.23110.2</CodefixTestingVersion>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicroBuildVersion>2.0.108</MicroBuildVersion>
+    <MicroBuildVersion>2.0.113</MicroBuildVersion>
     <CodeAnalysisVersionForAnalyzers>3.11.0</CodeAnalysisVersionForAnalyzers>
     <CodeAnalysisVersion>4.4.0</CodeAnalysisVersion>
     <CodefixTestingVersion>1.1.2-beta1.23110.2</CodefixTestingVersion>
@@ -15,14 +15,14 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="$(CodefixTestingVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" Version="$(CodefixTestingVersion)" />
-    <PackageVersion Include="Microsoft.CodeCoverage" Version="17.5.0-release-20230131-04" />
+    <PackageVersion Include="Microsoft.CodeCoverage" Version="17.5.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.4.16" />
     <PackageVersion Include="Microsoft.VisualStudio.RpcContracts" Version="17.4.9" />
     <PackageVersion Include="Microsoft.VisualStudio.Utilities" Version="17.4.33216.74" />
     <PackageVersion Include="Microsoft.VisualStudio.Utilities.Testing" Version="17.4.33216.74" />
     <PackageVersion Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" Version="17.3.37" />
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.4.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.5.21" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.2.188-beta" />

--- a/azure-pipelines/microbuild.after.yml
+++ b/azure-pipelines/microbuild.after.yml
@@ -8,6 +8,7 @@ steps:
   inputs:
     TargetFolders: |
       $(Build.SourcesDirectory)/bin/Packages/$(BuildConfiguration)/NuGet
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - task: MicroBuildCleanup@1
   condition: succeededOrFailed()
@@ -42,7 +43,7 @@ steps:
       /repoName:$(Build.Repository.Name)
       /additionalCodexArguments:-bld
       /additionalCodexArguments:$(Build.ArtifactStagingDirectory)/build_logs
-  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables['Build.Reason'], 'PullRequest'))
+  condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'), ne(variables['Build.Reason'], 'PullRequest'), eq(variables['Agent.OS'], 'Windows_NT'))
   continueOnError: true
 
 - ${{ if eq(parameters.EnableCompliance, 'true') }}:

--- a/azure-pipelines/microbuild.before.yml
+++ b/azure-pipelines/microbuild.before.yml
@@ -10,6 +10,7 @@ steps:
   inputs:
     outputfile: $(System.DefaultWorkingDirectory)/obj/NOTICE
     outputformat: text
+  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
 
 - task: MicroBuildOptProfPlugin@6
   inputs:
@@ -30,6 +31,8 @@ steps:
     signType: $(SignType)
     zipSources: false
   displayName: 🔧 Install MicroBuild Signing Plugin
+  condition: and(succeeded(), or(eq(variables['Agent.OS'], 'Windows_NT'), eq(variables['SignType'], 'real')))
 
 - task: MicroBuildSbomPlugin@1
   displayName: 🔧 Install MicroBuild Sbom Plugin
+  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))

--- a/azure-pipelines/prepare-insertion-stages.yml
+++ b/azure-pipelines/prepare-insertion-stages.yml
@@ -10,11 +10,8 @@ stages:
     - download: current
       artifact: Variables-Windows
       displayName: 🔻 Download Variables-Windows artifact
-    - task: PowerShell@2
+    - powershell: $(Pipeline.Workspace)/Variables-Windows/_pipelines.ps1
       displayName: ⚙️ Set pipeline variables based on artifacts
-      inputs:
-        targetType: filePath
-        filePath: $(Pipeline.Workspace)/Variables-Windows/_pipelines.ps1
     - download: current
       artifact: symbols-legacy
       displayName: 🔻 Download symbols-legacy artifact

--- a/azure-pipelines/release-deployment-prep.yml
+++ b/azure-pipelines/release-deployment-prep.yml
@@ -1,9 +1,6 @@
 steps:
 - download: CI
   artifact: Variables-Windows
-  displayName: Download Variables-Windows artifact
-- task: PowerShell@2
-  displayName: Set pipeline variables based on artifacts
-  inputs:
-    targetType: filePath
-    filePath: $(Pipeline.Workspace)/CI/Variables-Windows/_pipelines.ps1
+  displayName: 🔻 Download Variables-Windows artifact
+- powershell: $(Pipeline.Workspace)/CI/Variables-Windows/_pipelines.ps1
+  displayName: ⚙️ Set pipeline variables based on artifacts

--- a/azure-pipelines/vs-insertion.yml
+++ b/azure-pipelines/vs-insertion.yml
@@ -19,24 +19,24 @@ jobs:
   steps:
   - checkout: none
   - powershell: Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
-    displayName: Set pipeline name
+    displayName: ⚙️ Set pipeline name
   - task: UseDotNet@2
-    displayName: Install .NET SDK
+    displayName: ⚙️ Install .NET SDK
     inputs:
       packageType: sdk
       version: 6.x
   - task: NuGetAuthenticate@1
-    displayName: Authenticate NuGet feeds
+    displayName: 🔏 Authenticate NuGet feeds
     inputs:
       forceReinstallCredentialProvider: true
   - template: release-deployment-prep.yml
   - download: CI
     artifact: VSInsertion-Windows
-    displayName: Download VSInsertion-Windows artifact
+    displayName: 🔻 Download VSInsertion-Windows artifact
   - script: dotnet nuget push $(Pipeline.Workspace)\CI\VSInsertion-windows\*.nupkg -s https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json -k azdo --skip-duplicate
-    displayName: Push CoreXT packages to VS feed
+    displayName: 📦 Push CoreXT packages to VS feed
   - task: MicroBuildInsertVsPayload@4
-    displayName: Insert VS Payload
+    displayName: 🏭 Insert VS Payload
     inputs:
       TeamName: $(TeamName)
       TeamEmail: $(TeamEmail)
@@ -45,7 +45,7 @@ jobs:
       AutoCompletePR: true
       AutoCompleteMergeStrategy: Squash
   - task: MicroBuildCleanup@1
-    displayName: Send Telemetry
+    displayName: ☎️ Send Telemetry
   - powershell: |
       $contentType = 'application/json';
       $headers = @{ Authorization = 'Bearer $(System.AccessToken)' };
@@ -54,4 +54,4 @@ jobs:
       Write-Host $request
       $uri = "$(System.CollectionUri)$(System.TeamProject)/_apis/build/retention/leases?api-version=6.0-preview.1";
       Invoke-RestMethod -uri $uri -method POST -Headers $headers -ContentType $contentType -Body $request;
-    displayName: Retain inserted builds
+    displayName: 🗻 Retain inserted builds

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -36,30 +36,27 @@ stages:
       clean: true
       fetchDepth: 1
     - task: UseDotNet@2
-      displayName: Install .NET SDK
+      displayName: ⚙️ Install .NET SDK
       inputs:
         packageType: sdk
         version: 6.x
     - task: NuGetAuthenticate@1
-      displayName: Authenticate NuGet feeds
+      displayName: 🔏 Authenticate NuGet feeds
       inputs:
         forceReinstallCredentialProvider: true
     - download: current
       artifact: Variables-Windows
-      displayName: Download Variables-Windows artifact
-    - task: PowerShell@2
-      displayName: Set pipeline variables based on artifacts
-      inputs:
-        targetType: filePath
-        filePath: $(Pipeline.Workspace)/Variables-Windows/_pipelines.ps1
+      displayName: 🔻 Download Variables-Windows artifact
+    - powershell: $(Pipeline.Workspace)/Variables-Windows/_pipelines.ps1
+      displayName: ⚙️ Set pipeline variables based on artifacts
     - download: current
       artifact: VSInsertion-Windows
-      displayName: Download VSInsertion-Windows artifact
+      displayName: 🔻 Download VSInsertion-Windows artifact
     - script: dotnet nuget push VSInsertion-windows\*.nupkg -s https://pkgs.dev.azure.com/devdiv/_packaging/VS/nuget/v3/index.json -k azdo --skip-duplicate
-      displayName: Push CoreXT packages to VS feed
+      displayName: 📦 Push CoreXT packages to VS feed
       workingDirectory: $(Pipeline.Workspace)
     - task: MicroBuildInsertVsPayload@4
-      displayName: Insert VS Payload
+      displayName: 🏭 Insert VS Payload
       inputs:
         TeamName: $(TeamName)
         TeamEmail: $(TeamEmail)
@@ -78,7 +75,7 @@ stages:
         Remember to Abandon and (if allowed) to Delete Source Branch on that insertion PR when validation is complete.
         "@
         azure-pipelines/PostPRMessage.ps1 -AccessToken '$(System.AccessToken)' -Markdown $Markdown -Verbose
-      displayName: Comment on pull request
+      displayName: ✏️ Comment on pull request
       condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'))
     - task: MicroBuildCleanup@1
-      displayName: Send Telemetry
+      displayName: ☎️ Send Telemetry

--- a/init.ps1
+++ b/init.ps1
@@ -43,6 +43,8 @@
     Install the MicroBuild SBOM plugin.
 .PARAMETER AccessToken
     An optional access token for authenticating to Azure Artifacts authenticated feeds.
+.PARAMETER Interactive
+    Runs NuGet restore in interactive mode. This can turn authentication failures into authentication challenges.
 #>
 [CmdletBinding(SupportsShouldProcess = $true)]
 Param (
@@ -67,7 +69,9 @@ Param (
     [Parameter()]
     [switch]$SBOM,
     [Parameter()]
-    [string]$AccessToken
+    [string]$AccessToken,
+    [Parameter()]
+    [switch]$Interactive
 )
 
 $EnvVars = @{}
@@ -99,8 +103,14 @@ try {
     $HeaderColor = 'Green'
 
     if (!$NoRestore -and $PSCmdlet.ShouldProcess("NuGet packages", "Restore")) {
+        $RestoreArguments = @()
+        if ($Interactive)
+        {
+            $RestoreArguments += '--interactive'
+        }
+
         Write-Host "Restoring NuGet packages" -ForegroundColor $HeaderColor
-        dotnet restore
+        dotnet restore @RestoreArguments
         if ($lastexitcode -ne 0) {
             throw "Failure while restoring packages."
         }

--- a/tools/Install-DotNetSdk.ps1
+++ b/tools/Install-DotNetSdk.ps1
@@ -92,19 +92,18 @@ Function Get-FileFromWeb([Uri]$Uri, $OutDir) {
 }
 
 Function Get-InstallerExe(
-    $Version,
+    [Version]$Version,
     $Architecture,
     [ValidateSet('Sdk','Runtime','WindowsDesktop')]
     [string]$sku
 ) {
     # Get the latest/actual version for the specified one
-    $TypedVersion = [Version]$Version
-    if ($TypedVersion.Build -eq -1) {
+    if ($Version.Build -eq -1) {
         $versionInfo = -Split (Invoke-WebRequest -Uri "https://dotnetcli.blob.core.windows.net/dotnet/$sku/$Version/latest.version" -UseBasicParsing)
         $Version = $versionInfo[-1]
     }
 
-    $majorMinor = "$($TypedVersion.Major).$($TypedVersion.Minor)"
+    $majorMinor = "$($Version.Major).$($Version.Minor)"
     $ReleasesFile = Join-Path $DotNetInstallScriptRoot "$majorMinor\releases.json"
     if (!(Test-Path $ReleasesFile)) {
         Get-FileFromWeb -Uri "https://dotnetcli.blob.core.windows.net/dotnet/release-metadata/$majorMinor/releases.json" -OutDir (Split-Path $ReleasesFile) | Out-Null


### PR DESCRIPTION
- Skip generating the NOTICE file on PR builds
- Add emojis to insertion pipeline steps
- Simplify Version cast in ps1 script
- Add more emojis and use simpler powershell task syntax
- Use LF line endings for plist files
- Add `-interactive` switch to init.ps1
- Bump MicroBuild to 2.0.112
- Remove certain tasks on non-Windows agents
- Bump dependencies to 17.5.0 versions
- Add msbuild extension for VS Code
- Drop test-tools as a nuget feed source
- Bump MicroBuild version
