### PR TITLE
Add System.Text.Json workarounds

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/FrameworkServices.cs
+++ b/src/Microsoft.ServiceHub.Framework/FrameworkServices.cs
@@ -44,7 +44,7 @@ public static class FrameworkServices
 	/// </remarks>
 	public static readonly ServiceRpcDescriptor RemoteBrokeredServiceManifest = new CamelCaseTransformingDescriptor(
 		new ServiceMoniker("Microsoft.VisualStudio.RemoteBrokeredServiceManifest", new Version(0, 2)),
-		ServiceJsonRpcDescriptor.Formatters.UTF8, // STJ use blocked by https://github.com/dotnet/runtime/issues/85981
+		ServiceJsonRpcDescriptor.Formatters.UTF8SystemTextJson,
 		ServiceJsonRpcDescriptor.MessageDelimiters.HttpLikeHeaders);
 
 	/// <summary>

--- a/src/Microsoft.ServiceHub.Framework/JsonConverterWrapper`1.cs
+++ b/src/Microsoft.ServiceHub.Framework/JsonConverterWrapper`1.cs
@@ -1,0 +1,44 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Microsoft.ServiceHub.Framework;
+
+/// <summary>
+/// Wraps a built-in converter with a custom one to workaround <see href="https://github.com/dotnet/runtime/issues/85981">this bug in System.Text.Json</see>.
+/// </summary>
+/// <typeparam name="T">The type the converter supports.</typeparam>
+/// <remarks>
+/// We should be able to remove this class and its users once we upgrade to System.Text.Json 8.0.0.
+/// </remarks>
+internal sealed class JsonConverterWrapper<T> : JsonConverter<T>
+{
+	/// <summary>
+	/// The singleton instance of the converter.
+	/// </summary>
+	internal static readonly JsonConverter<T> Instance = new JsonConverterWrapper<T>();
+
+	private static readonly JsonConverter<T> BuiltInConverter = (JsonConverter<T>)JsonSerializerOptions.Default.GetTypeInfo(typeof(T)).Converter;
+
+	private JsonConverterWrapper()
+	{
+	}
+
+	/// <inheritdoc/>
+	public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+		=> BuiltInConverter.Write(writer, value, options);
+
+	/// <inheritdoc/>
+	public override T? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		=> BuiltInConverter.Read(ref reader, typeToConvert, options);
+
+	/// <inheritdoc/>
+	public override T ReadAsPropertyName(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		=> BuiltInConverter.ReadAsPropertyName(ref reader, typeToConvert, options);
+
+	/// <inheritdoc/>
+	public override void WriteAsPropertyName(Utf8JsonWriter writer, T value, JsonSerializerOptions options)
+		=> BuiltInConverter.WriteAsPropertyName(writer, value, options);
+}

--- a/src/Microsoft.ServiceHub.Framework/ServiceJsonRpcDescriptor.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServiceJsonRpcDescriptor.cs
@@ -407,6 +407,12 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 				DictionaryKeyPolicy = null,
 				PropertyNamingPolicy = STJ.JsonNamingPolicy.CamelCase,
 				DefaultIgnoreCondition = STJ.Serialization.JsonIgnoreCondition.WhenWritingNull,
+				Converters =
+				{
+					// These converters are a workaround for https://github.com/dotnet/runtime/issues/85981
+					JsonConverterWrapper<Version>.Instance,
+					JsonConverterWrapper<Uri>.Instance,
+				},
 			},
 		};
 	}


### PR DESCRIPTION
This works around https://github.com/dotnet/runtime/issues/85981 so we can move forward with System.Text.Json migration.

Not all the workarounds necessary to fully emulate dotnet/runtime#86056 (the fix) are in place here, both because some code changes cannot be replicated in our own code due to accessing internal APIs, and because some of them seem less likely to be used so I didn't bother.

CC: @eiriktsarpalis