### PR TITLE
Stabilize a node.js test

### DIFF
--- a/src/servicebroker-npm/src/ServiceJsonRpcDescriptor.ts
+++ b/src/servicebroker-npm/src/ServiceJsonRpcDescriptor.ts
@@ -194,7 +194,7 @@ const rpcProxy = {
 			default:
 				return function () {
 					const methodName = property.toString()
-					return invokeRpc(property.toString(), arguments, target.messageConnection)
+					return invokeRpc(methodName, arguments, target.messageConnection)
 				}
 		}
 	},

--- a/src/servicebroker-npm/test/testAssets/testUtilities.ts
+++ b/src/servicebroker-npm/test/testAssets/testUtilities.ts
@@ -80,3 +80,7 @@ export const appleTreeDescriptor: ServiceJsonRpcDescriptor = new ServiceJsonRpcD
 	Formatters.Utf8,
 	MessageDelimiters.HttpLikeHeaders
 )
+
+export function delay(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms))
+}


### PR DESCRIPTION
The issue was the scope of the constructed promise accidentally included actually invoking and awaiting on the RPC call, such that the promise would resolve and the test would finish before the RPC call finished. That led to a rejected promise from an abandoned RPC call, which (infuriatingly) causes failures in a _subsequent_ test. It took a while to find the root cause.

BTW, the very next test in this file has the same problem, although it hasn't shown up as a stability problem (yet). But fixing it there causes another problem to manifest which I haven't ironed out yet, so that fix will have to come in a subsequent change, since _this_ PR is badly needed to resolve pipelines failing regularly.