### PR TITLE
Fix MEF-activated brokered service client callbacks over a pipe

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/Container/ServiceBrokerForExportedBrokeredServices.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/ServiceBrokerForExportedBrokeredServices.cs
@@ -142,8 +142,8 @@ internal class ServiceBrokerForExportedBrokeredServices : IServiceBroker, IDispo
 	/// Activates the one brokered service indicated by the <see cref="ActivatedMoniker"/> property.
 	/// </summary>
 	/// <param name="cancellationToken">A cancellation token.</param>
-	/// <returns>The activated service.</returns>
-	internal async ValueTask<IExportedBrokeredService?> CreateBrokeredServiceAsync(CancellationToken cancellationToken)
+	/// <returns>The activated service. The caller should invoke <see cref="IExportedBrokeredService.InitializeAsync(CancellationToken)"/> on the result.</returns>
+	internal IExportedBrokeredService? CreateBrokeredService(CancellationToken cancellationToken)
 	{
 		Verify.Operation(this.ActivatedMoniker is not null, "Exporting properties must be set first.");
 
@@ -155,7 +155,6 @@ internal class ServiceBrokerForExportedBrokeredServices : IServiceBroker, IDispo
 				if (this.ActivatedMoniker.Name == factory.Metadata.ServiceName[i] && requiredVersion == factory.Metadata.ServiceVersion[i])
 				{
 					Verify.Operation(!factory.IsValueCreated, "This method should only be called once.");
-					await factory.Value.InitializeAsync(cancellationToken).ConfigureAwait(false);
 					return factory.Value;
 				}
 			}


### PR DESCRIPTION
When a MEF-activated brokered service is activated over a pipe, the `ServiceActivationOptions.ClientRpcTarget` property was always null, even when the service-side descriptor calls for a target proxy.

The creation of the proxy back to the client is the responsibility of the MEF implementation of `IServiceBroker`. But the service broker only knows how to create it by looking at the descriptor. And the descriptor is only available *after* activating the brokered service, because it is an instance property on the MEF part that implements the brokered service. But by the time the MEF part is activated, its imports (including of `ServiceActivationOptions`) must have already been satisfied. So we have a chicken-and-egg problem.

To resolve it, we create the brokered service, but before fully initializing it, we get its descriptor, and *if it requests a client proxy* we dispose of that brokered service and re-activate it with a modified `ServiceActivationOptions` that includes the proxy.

While it feels odd to activate, dispose, and re-activate a brokered service for one client request, I don't see a better way. And it shouldn't be a breaking behavioral change because it only impacts brokered services that would have been broken before on account of not getting the client proxy they were expecting. So I see this as enabling a new scenario. And technically, the calling pattern has always been a possibility (say, a botched activation followed by a successful one), so it shouldn't be a problem.