### PR TITLE
Fix brokered service query failures when multiple requests come in early

### DIFF
--- a/src/servicebroker-npm/src/container/ServiceRegistration.ts
+++ b/src/servicebroker-npm/src/container/ServiceRegistration.ts
@@ -7,12 +7,12 @@ export class ServiceRegistration {
 	 * Initializes a new instance of the ServiceRegistration class.
 	 * @param audience the intended audiences for this service.
 	 * @param allowGuestClients a value indicating whether this service is exposed to non-Owner clients.
-	 * @param profferCallback an optional callback that should be invoked the first time this service is activated in order to proffer the service to the container
+	 * @param profferCallback an optional callback that should be invoked the first time this service is activated in order to proffer the service to the container, or a promise that resolves when the service is proffered.
 	 */
 	constructor(
 		public readonly audience: ServiceAudience,
 		public readonly allowGuestClients: boolean,
-		public profferCallback?: (container: IBrokeredServiceContainer, moniker: ServiceMoniker) => Promise<void> | void
+		public profferCallback?: ((container: IBrokeredServiceContainer, moniker: ServiceMoniker) => Promise<void> | void) | Promise<void>
 	) {}
 
 	/** Gets a value indicating whether this service is exposed to local clients relative to itself. */


### PR DESCRIPTION
We had a bug where if a brokered service is registered with a proferring callback, only the *first* request would invoke and wait on that callback. All subsequent requests would skip over that and fail if the callback hadn't finished by proffering the service factory yet.
The fix is to ensure that while only the first request should *invoke* the callback, *all* requests should await the result of that callback (if in fact it is awaitable) so that no request fails simply because it was made before the service was proferred.
