### PR TITLE
Merge latest Library.Template

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicroBuildVersion>2.0.125</MicroBuildVersion>
+    <MicroBuildVersion>2.0.127</MicroBuildVersion>
     <CodeAnalysisVersionForAnalyzers>3.11.0</CodeAnalysisVersionForAnalyzers>
     <CodeAnalysisVersion>4.5.0</CodeAnalysisVersion>
     <CodefixTestingVersion>1.1.2-beta1.23251.2</CodefixTestingVersion>

--- a/azure-pipelines/Archive-SourceCode.ps1
+++ b/azure-pipelines/Archive-SourceCode.ps1
@@ -155,7 +155,7 @@ if (!$RepoUrl) {
 }
 
 Push-Location $PSScriptRoot
-$versionsObj = dotnet tool run nbgv get-version -f json | ConvertFrom-Json
+$versionsObj = dotnet nbgv get-version -f json | ConvertFrom-Json
 Pop-Location
 
 $ReleaseDateString = $ReleaseDate.ToShortDateString()

--- a/azure-pipelines/Get-SymbolFiles.ps1
+++ b/azure-pipelines/Get-SymbolFiles.ps1
@@ -43,8 +43,13 @@ $PDBs |% {
     }
 } |% {
     # Collect the DLLs/EXEs as well.
-    $dllPath = "$($_.Directory)/$($_.BaseName).dll"
-    $exePath = "$($_.Directory)/$($_.BaseName).exe"
+    $rootName = "$($_.Directory)/$($_.BaseName)"
+    if ($rootName.EndsWith('.ni')) {
+        $rootName = $rootName.Substring(0, $rootName.Length - 3)
+    }
+
+    $dllPath = "$rootName.dll"
+    $exePath = "$rootName.exe"
     if (Test-Path $dllPath) {
         $BinaryImagePath = $dllPath
     } elseif (Test-Path $exePath) {

--- a/azure-pipelines/Merge-CodeCoverage.ps1
+++ b/azure-pipelines/Merge-CodeCoverage.ps1
@@ -42,7 +42,7 @@ try {
             New-Item -Type Directory -Path (Split-Path $OutputFile) | Out-Null
         }
 
-        & dotnet tool run dotnet-coverage merge $Inputs -o $OutputFile -f cobertura
+        & dotnet dotnet-coverage merge $Inputs -o $OutputFile -f cobertura
     } else {
         Write-Error "No reports found to merge."
     }

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -15,10 +15,10 @@ parameters:
   default: true
 - name: EnableCompliance
   type: boolean
-  default: true
+  default: false
 - name: EnableAPIScan
   type: boolean
-  default: true
+  default: false
 
 jobs:
 - job: Windows

--- a/azure-pipelines/variables/InsertVersionsValues.ps1
+++ b/azure-pipelines/variables/InsertVersionsValues.ps1
@@ -6,5 +6,5 @@
 $MacroName = 'MicrosoftServiceHubFrameworkVersion'
 $SampleProject = "$PSScriptRoot\..\..\src\Microsoft.ServiceHub.Framework"
 [string]::join(',',(@{
-    ($MacroName) = & { (dotnet tool run nbgv -- get-version --project $SampleProject --format json | ConvertFrom-Json).AssemblyVersion };
+    ($MacroName) = & { (dotnet nbgv get-version --project $SampleProject --format json | ConvertFrom-Json).AssemblyVersion };
 }.GetEnumerator() |% { "$($_.key)=$($_.value)" }))

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -17,8 +17,6 @@ stages:
   jobs:
   - template: build.yml
     parameters:
-      EnableCompliance: false
-      EnableAPIScan: false
       windowsPool: VSEngSS-MicroBuild2022-1ES
       includeMacOS: false
       RunTests: false

--- a/init.ps1
+++ b/init.ps1
@@ -113,12 +113,6 @@ try {
     }
 
     if (!$NoRestore -and $PSCmdlet.ShouldProcess("NuGet packages", "Restore")) {
-        $RestoreArguments = @()
-        if ($Interactive)
-        {
-            $RestoreArguments += '--interactive'
-        }
-
         Write-Host "Restoring NuGet packages" -ForegroundColor $HeaderColor
         dotnet restore @RestoreArguments
         if ($lastexitcode -ne 0) {


### PR DESCRIPTION
- Update Dockerfile
- Fix placement of $RestoreArguments construction
- Switch from `MSBuildTreatWarningsAsErrors` to `-warnaserror`
- Fix BinSkim when ApiScan won't run
- Bump .NET SDK to 7.0.302
- Parameterize and add diagnostics to InsertVersionsValues.ps1
- Fix schedule triggered source code archival
- Upgrade archive symbols task to v4
-  Consolidate two stages to just one
- Bump NB.GV to 3.6.132
- Bump CSharpIsNullAnalyzer from 0.1.329 to 0.1.495 (#204)
- Bump Microsoft.NET.Test.Sdk from 17.5.0 to 17.6.0 (#202)
- Bump dotnet-coverage from 17.7.0 to 17.7.1 (#205)
- (Hopefully) fix `nbgv` failures with `--` argument separator
- Fix indentation of commented section
- Bump Nerdbank.GitVersioning to 3.6.133
- Bump Microsoft.NET.Test.Sdk to 17.6.1
- Enable dependabot for Azure Repos
- Bump Microsoft.NET.Test.Sdk to 17.6.2
- Bump MicroBuild to 2.0.125
- Fix symbol file selection for R2R outputs
- Simplify `nbgv` invocation in ps1 scripts
- Skip compliance checks by default for build.yml
- Bump MicroBuild to 2.0.127
- Bump dotnet-coverage to 17.7.2
