### PR TITLE
Use precise assembly version for analyzers project

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -20,9 +20,6 @@
     <!-- Opt back out until an SDK with the fix for https://github.com/NuGet/Home/issues/12177 is generally available. -->
     <RestoreUseStaticGraphEvaluation>false</RestoreUseStaticGraphEvaluation>
 
-    <!-- This entire repo has just one version.json file, so compute the version once and share with all projects in a large build. -->
-    <GitVersionBaseDirectory>$(MSBuildThisFileDirectory)</GitVersionBaseDirectory>
-
     <!-- Local builds should embed PDBs so we never lose them when a subsequent build occurs. -->
     <DebugType Condition=" '$(CI)' != 'true' and '$(TF_BUILD)' != 'true' ">embedded</DebugType>
 


### PR DESCRIPTION
This removes an MSBuild property that makes version calculating happen only once per build, under the (incorrect) assumption that only one version.json file exists in this repo. But the analyzers project has a unique one, and this msbuild property was causing that to be ignored.

See also https://github.com/microsoft/vs-mef/pull/437 for a similar bug and fix.