### PR TITLE
Add `ServiceBrokerAggregator.NonDisposable` method

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.ServiceHub.Framework/PublicAPI.Unshipped.txt
@@ -7,3 +7,4 @@ override Microsoft.ServiceHub.Framework.DelegatingServiceJsonRpcDescriptor.Creat
 override Microsoft.ServiceHub.Framework.DelegatingServiceJsonRpcDescriptor.CreateFormatter() -> StreamJsonRpc.IJsonRpcMessageFormatter!
 override Microsoft.ServiceHub.Framework.DelegatingServiceJsonRpcDescriptor.CreateHandler(System.IO.Pipelines.IDuplexPipe! pipe, StreamJsonRpc.IJsonRpcMessageFormatter! formatter) -> StreamJsonRpc.IJsonRpcMessageHandler!
 override Microsoft.ServiceHub.Framework.DelegatingServiceJsonRpcDescriptor.CreateJsonRpc(StreamJsonRpc.IJsonRpcMessageHandler! handler) -> StreamJsonRpc.JsonRpc!
+static Microsoft.ServiceHub.Framework.ServiceBrokerAggregator.NonDisposable(Microsoft.ServiceHub.Framework.IServiceBroker! serviceBroker) -> Microsoft.ServiceHub.Framework.IServiceBroker!

--- a/src/Microsoft.ServiceHub.Framework/ServiceBrokerAggregator.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServiceBrokerAggregator.cs
@@ -38,6 +38,19 @@ public static class ServiceBrokerAggregator
 	public static IServiceBroker ForceMarshal(IServiceBroker serviceBroker) => new ForceMarshalingBroker(serviceBroker);
 
 	/// <summary>
+	/// Creates a new <see cref="IServiceBroker"/> that does not implement <see cref="IDisposable"/>
+	/// and forwards all requests to a given <see cref="IServiceBroker"/>.
+	/// </summary>
+	/// <param name="serviceBroker">The inner service broker to forward requests to.</param>
+	/// <returns>The non-disposable wrapper.</returns>
+	/// <remarks>
+	/// This is useful when an <see cref="IServiceBroker"/> that may implement <see cref="IDisposable"/> is being shared
+	/// such that others <em>may</em> dispose of it if it is disposable, but the caller wants to retain exclusive control
+	/// over the lifetime of the broker.
+	/// </remarks>
+	public static IServiceBroker NonDisposable(IServiceBroker serviceBroker) => new NonDisposingServiceBroker(serviceBroker);
+
+	/// <summary>
 	/// A broker which will query many other brokers sequentially, and return the first successful result.
 	/// </summary>
 	private sealed class SequentialBroker : IServiceBroker, IDisposable
@@ -201,27 +214,69 @@ public static class ServiceBrokerAggregator
 		private void OnAvailabilityChanged(object? sender, BrokeredServicesChangedEventArgs args) => this.AvailabilityChanged?.Invoke(this, args);
 	}
 
+	private class DelegatingServiceBroker : IServiceBroker
+	{
+		private readonly object syncObject = new();
+		private EventHandler<BrokeredServicesChangedEventArgs>? availabilityChanged;
+
+		internal DelegatingServiceBroker(IServiceBroker inner) => this.Inner = Requires.NotNull(inner);
+
+		public event EventHandler<BrokeredServicesChangedEventArgs>? AvailabilityChanged
+		{
+			add
+			{
+				lock (this.syncObject)
+				{
+					if (this.availabilityChanged is null)
+					{
+						this.Inner.AvailabilityChanged += this.OnInnerAvailabilityChanged;
+					}
+
+					this.availabilityChanged += value;
+				}
+			}
+
+			remove
+			{
+				lock (this.syncObject)
+				{
+					this.availabilityChanged -= value;
+
+					if (this.availabilityChanged is null)
+					{
+						this.Inner.AvailabilityChanged -= this.OnInnerAvailabilityChanged;
+					}
+				}
+			}
+		}
+
+		protected IServiceBroker Inner { get; }
+
+		public virtual ValueTask<IDuplexPipe?> GetPipeAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions options = default, CancellationToken cancellationToken = default)
+			=> this.Inner.GetPipeAsync(serviceMoniker, options, cancellationToken);
+
+		public virtual ValueTask<T?> GetProxyAsync<T>(ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options = default, CancellationToken cancellationToken = default)
+			where T : class
+			=> this.Inner.GetProxyAsync<T>(serviceDescriptor, options, cancellationToken);
+
+		private void OnInnerAvailabilityChanged(object? sender, BrokeredServicesChangedEventArgs e)
+		{
+			// We explicitly forward all events so that our subscribers see `this` as the sender
+			// instead of `inner`.
+			this.availabilityChanged?.Invoke(this, e);
+		}
+	}
+
 	/// <summary>
 	/// Wraps an <see cref="IServiceBroker"/> such that any locally provisioned service is forced to marshal all calls anyway.
 	/// </summary>
-	private sealed class ForceMarshalingBroker : IServiceBroker, IDisposable
+	private class ForceMarshalingBroker(IServiceBroker inner) : DelegatingServiceBroker(inner)
 	{
-		private readonly IServiceBroker inner;
-
-		public ForceMarshalingBroker(IServiceBroker inner)
-		{
-			this.inner = inner ?? throw new ArgumentNullException(nameof(inner));
-			this.inner.AvailabilityChanged += this.OnAvailabilityChanged;
-		}
-
 		/// <inheritdoc />
-		public event EventHandler<BrokeredServicesChangedEventArgs>? AvailabilityChanged;
-
-		/// <inheritdoc />
-		public async ValueTask<T?> GetProxyAsync<T>(ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options, CancellationToken cancellationToken)
+		public override async ValueTask<T?> GetProxyAsync<T>(ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options, CancellationToken cancellationToken)
 			where T : class
 		{
-			IDuplexPipe? pipe = await this.inner.GetPipeAsync(serviceDescriptor.Moniker, options, cancellationToken).ConfigureAwait(false);
+			IDuplexPipe? pipe = await this.Inner.GetPipeAsync(serviceDescriptor.Moniker, options, cancellationToken).ConfigureAwait(false);
 			if (pipe is null)
 			{
 				return null;
@@ -238,25 +293,7 @@ public static class ServiceBrokerAggregator
 				throw;
 			}
 		}
-
-		/// <inheritdoc />
-		public ValueTask<IDuplexPipe?> GetPipeAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions options, CancellationToken cancellationToken)
-		{
-			// Marshaling is already applied.
-			return this.inner.GetPipeAsync(serviceMoniker, options, cancellationToken);
-		}
-
-		/// <inheritdoc />
-		public void Dispose()
-		{
-			this.inner.AvailabilityChanged -= this.OnAvailabilityChanged;
-		}
-
-		/// <summary>
-		/// Raises the <see cref="AvailabilityChanged"/> event.
-		/// </summary>
-		/// <param name="sender">This parameter is ignored. The event will be raised with "this" as the sender.</param>
-		/// <param name="args">Details regarding what changes have occurred.</param>
-		private void OnAvailabilityChanged(object? sender, BrokeredServicesChangedEventArgs args) => this.AvailabilityChanged?.Invoke(this, args);
 	}
+
+	private class NonDisposingServiceBroker(IServiceBroker inner) : DelegatingServiceBroker(inner);
 }


### PR DESCRIPTION
This provides a means to 'hide' disposability of a particular `IServiceBroker` object before sharing it.