### PR TITLE
Improve ISB001 analyzer syntax handling

### DIFF
--- a/src/Microsoft.ServiceHub.Analyzers/ISB001DisposeOfProxiesAnalyzer.cs
+++ b/src/Microsoft.ServiceHub.Analyzers/ISB001DisposeOfProxiesAnalyzer.cs
@@ -162,6 +162,9 @@ public class ISB001DisposeOfProxiesAnalyzer : DiagnosticAnalyzer
 			case IUsingOperation { Resources: IConversionOperation { Operand: ILocalReferenceOperation { Local: { } local } } }:
 				// using (proxy as IDisposable)
 				return SymbolEqualityComparer.Default.Equals(local, symbol);
+			case IUsingOperation { Resources: ILocalReferenceOperation { Local: { } local } }:
+				// using (proxy)
+				return SymbolEqualityComparer.Default.Equals(local, symbol);
 			default:
 				return false;
 		}
@@ -255,6 +258,12 @@ public class ISB001DisposeOfProxiesAnalyzer : DiagnosticAnalyzer
 
 			// 4. Inside the resource expression of a using block.
 			if (Utils.FindAncestors<IUsingOperation>(operation).FirstOrDefault()?.Resources.Descendants().Contains(operation) ?? false)
+			{
+				return;
+			}
+
+			// 5. Inside the resource expression of a using declaration.
+			if (Utils.FindAncestors<IUsingDeclarationOperation>(operation).Any())
 			{
 				return;
 			}

--- a/test/Microsoft.ServiceHub.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
+++ b/test/Microsoft.ServiceHub.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
@@ -6,13 +6,14 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Testing.Verifiers;
 using Microsoft.CodeAnalysis.Text;
 using Microsoft.ServiceHub.Framework;
 
 public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 {
-	public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
+	public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, DefaultVerifier>
 	{
 		public Test()
 		{

--- a/test/Microsoft.ServiceHub.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2.cs
+++ b/test/Microsoft.ServiceHub.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2.cs
@@ -13,10 +13,10 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 	where TCodeFix : CodeFixProvider, new()
 {
 	public static DiagnosticResult Diagnostic()
-		=> CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic();
+		=> CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic();
 
 	public static DiagnosticResult Diagnostic(string diagnosticId)
-		=> CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(diagnosticId);
+		=> CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic(diagnosticId);
 
 	public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
 		=> new DiagnosticResult(descriptor);

--- a/test/Microsoft.ServiceHub.Analyzers.Tests/ISB001DisposeOfProxiesAnalyzerTests.cs
+++ b/test/Microsoft.ServiceHub.Analyzers.Tests/ISB001DisposeOfProxiesAnalyzerTests.cs
@@ -117,6 +117,55 @@ class Test {
 	}
 
 	[Fact]
+	public async Task GetProxyAsync_DisposedByUsingWithoutCast()
+	{
+		string test = Preamble + @"
+interface IFooDisposable : IFoo, IDisposable {}
+class Test {
+    async Task Foo(IServiceBroker sb) {
+        IFooDisposable client = await sb.GetProxyAsync<IFooDisposable>(Stock.Descriptor);
+        using (client) {
+            """".ToString(); // something else that might throw
+        }
+    }
+}
+";
+
+		await Verify.VerifyAnalyzerAsync(test);
+	}
+
+	[Fact]
+	public async Task GetProxyAsync_DisposedByUsingLocalDeclaration()
+	{
+		string test = Preamble + @"
+interface IFooDisposable : IFoo, IDisposable {}
+class Test {
+    async Task Foo(IServiceBroker sb) {
+        using IFooDisposable client = await sb.GetProxyAsync<IFooDisposable>(Stock.Descriptor);
+        """".ToString(); // something else that might throw
+    }
+}
+";
+
+		await Verify.VerifyAnalyzerAsync(test);
+	}
+
+	[Fact]
+	public async Task ServiceBrokerClient_DisposedByUsingLocalDeclaration()
+	{
+		string test = Preamble + @"
+class Test {
+    void Foo(IServiceBroker sb) {
+        using ServiceBrokerClient client = new(sb);
+        """".ToString(); // something else that might throw
+    }
+}
+";
+
+		await Verify.VerifyAnalyzerAsync(test);
+	}
+
+	[Fact]
 	public async Task GetProxyAsync_UnconditionalCastToIDisposable()
 	{
 		string test = Preamble + @"


### PR DESCRIPTION
This adds support for:
- `using (proxy)` (without a cast to IDisposable)
- `using var proxy = await sb.GetProxyAsync();` (declaration instead of block)

Fixes #187