### PR TITLE
Allow public access to ServiceJsonRpcDescriptor.CreateFormatter

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.ServiceHub.Framework/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@ Microsoft.ServiceHub.Framework.DelegatingServiceJsonRpcDescriptor
 Microsoft.ServiceHub.Framework.DelegatingServiceJsonRpcDescriptor.ApplySettingsToInnerDescriptor() -> void
 Microsoft.ServiceHub.Framework.DelegatingServiceJsonRpcDescriptor.DelegatingServiceJsonRpcDescriptor(Microsoft.ServiceHub.Framework.DelegatingServiceJsonRpcDescriptor! descriptor) -> void
 Microsoft.ServiceHub.Framework.DelegatingServiceJsonRpcDescriptor.DelegatingServiceJsonRpcDescriptor(Microsoft.ServiceHub.Framework.ServiceJsonRpcDescriptor! innerDescriptor) -> void
+Microsoft.ServiceHub.Framework.ServiceJsonRpcDescriptor.GetFormatter() -> StreamJsonRpc.IJsonRpcMessageFormatter!
 override Microsoft.ServiceHub.Framework.DelegatingServiceJsonRpcDescriptor.ConstructRpcConnection(System.IO.Pipelines.IDuplexPipe! pipe) -> Microsoft.ServiceHub.Framework.ServiceRpcDescriptor.RpcConnection!
 override Microsoft.ServiceHub.Framework.DelegatingServiceJsonRpcDescriptor.CreateConnection(StreamJsonRpc.JsonRpc! jsonRpc) -> Microsoft.ServiceHub.Framework.ServiceJsonRpcDescriptor.JsonRpcConnection!
 override Microsoft.ServiceHub.Framework.DelegatingServiceJsonRpcDescriptor.CreateFormatter() -> StreamJsonRpc.IJsonRpcMessageFormatter!

--- a/src/Microsoft.ServiceHub.Framework/ServiceJsonRpcDescriptor.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServiceJsonRpcDescriptor.cs
@@ -280,6 +280,12 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 	}
 
 	/// <summary>
+	/// Initializes a new instance of <see cref="IJsonRpcMessageFormatter"/> for use in a new server or client.
+	/// </summary>
+	/// <returns>The new message formatter.</returns>
+	public IJsonRpcMessageFormatter GetFormatter() => this.CreateFormatter();
+
+	/// <summary>
 	/// Returns an instance of <see cref="ServiceJsonRpcDescriptor"/> that resembles this one,
 	/// but with <see cref="ExceptionStrategy"/>, <see cref="MultiplexingStreamOptions"/>, <see cref="JoinableTaskFactory"/> and <see cref="TraceSource"/> matching to passed in descriptor.
 	/// </summary>


### PR DESCRIPTION
There are current implementations that wrap an existing `ServiceJsonRpcDescriptor` into another `ServiceJsonRpcDescriptor`-derived class.
These implementations need to call `CreateFormatter` on the inner descriptor and they currently use reflection to do so.
Unfortunately `CreateFormatter` is `protected internal`, so it cannot be made public without breaking the compilation of extended classes that are overriding this method.
For this reason, I propose creating a new public method to make the `CreateFormatter` capability publicly accessible.