### PR TITLE
Wrap TraceEvent() in try/catch to avoid intermittent IOException

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.cs
@@ -428,9 +428,16 @@ public abstract partial class GlobalBrokeredServiceContainer : IBrokeredServiceC
 			this.profferedServiceIndex = this.profferedServiceIndex.SetItem(proffered.Source, monikerAndProfferBuilder.ToImmutable());
 		}
 
-		if (this.traceSource.Switch.ShouldTrace(TraceEventType.Information))
+		try
 		{
-			this.traceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.Proffered, "{0} proffered brokered service(s): {1}.", proffered.Source, ServiceBrokerUtilities.DeferredFormatting(() => string.Join(", ", proffered.Monikers)));
+			if (this.traceSource.Switch.ShouldTrace(TraceEventType.Information))
+			{
+				this.traceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.Proffered, "{0} proffered brokered service(s): {1}.", proffered.Source, ServiceBrokerUtilities.DeferredFormatting(() => string.Join(", ", proffered.Monikers)));
+			}
+		}
+		catch
+		{
+			// TraceEvent() will intermittently raise IOException that we can ignore. Eat the exception.
 		}
 
 		this.OnAvailabilityChanged(oldIndex, proffered);


### PR DESCRIPTION
Addressing uncaught exception in Watson crash: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2104771/