### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.4.2",
+      "version": "7.4.3",
       "commands": [
         "pwsh"
       ]

--- a/.gitignore
+++ b/.gitignore
@@ -353,3 +353,6 @@ MigrationBackup/
 
 # mac-created file to track user view preferences for a directory
 .DS_Store
+
+# Analysis results
+*.sarif

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -6,7 +6,6 @@
     <BaseIntermediateOutputPath>$(RepoRootPath)obj\$([MSBuild]::MakeRelative($(RepoRootPath), $(MSBuildProjectDirectory)))\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\NuGet\</PackageOutputPath>
-    <LangVersion>12</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
+  <PropertyGroup>
+    <LangVersion Condition="'$(Language)'=='C#'">12</LangVersion>
+    <LangVersion Condition="'$(Language)'=='VB'">16.9</LangVersion>
+  </PropertyGroup>
   <ItemGroup>
     <!-- Avoid compile error about missing namespace when combining ImplicitUsings with .NET Framework target frameworks. -->
     <Using Remove="System.Net.Http" Condition="'$(TargetFrameworkIdentifier)'=='.NETFramework'" />

--- a/azure-pipelines/Archive-SourceCode.ps1
+++ b/azure-pipelines/Archive-SourceCode.ps1
@@ -35,7 +35,7 @@
 .PARAMETER SourceCodeArchivalUri
     The URI to POST the source code archival request to.
     This value will typically come automatically by a variable group associated with your pipeline.
-    You can also look it up at https://dpsrequestforms.azurewebsites.net/#/help -> SCA Request Help -> SCA API Help -> Description
+    You can also look it up at https://dpsopsrequestforms.azurewebsites.net/#/help -> SCA Request Help -> SCA API Help -> Description
 #>
 [CmdletBinding(SupportsShouldProcess = $true, PositionalBinding = $false)]
 param (
@@ -76,7 +76,9 @@ param (
     [Parameter()]
     [string]$ServerPath = '',
     [Parameter()]
-    [Uri]$SourceCodeArchivalUri = $env:SOURCECODEARCHIVALURI
+    [Uri]$SourceCodeArchivalUri = $env:SOURCECODEARCHIVALURI,
+    [Parameter(Mandatory = $true)]
+    [string]$AccessToken
 )
 
 function Invoke-Git() {
@@ -199,9 +201,13 @@ if ($PSCmdlet.ShouldProcess('source archival request', 'post')) {
         exit 1
     }
 
+    $headers = @{
+        'Authorization' = "Bearer $AccessToken"
+    }
+
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-    $Response = Invoke-WebRequest -Uri $SourceCodeArchivalUri -Method POST -Body $RequestJson -ContentType "application/json" -UseBasicParsing -SkipHttpErrorCheck
+    $Response = Invoke-WebRequest -Uri $SourceCodeArchivalUri -Method POST -Headers $headers -Body $RequestJson -ContentType "application/json" -UseBasicParsing -SkipHttpErrorCheck
     Write-Host "Status Code : " -NoNewline
     if ($Response.StatusCode -eq 200) {
         Write-Host $Response.StatusCode -ForegroundColor Green

--- a/azure-pipelines/Get-SymbolFiles.ps1
+++ b/azure-pipelines/Get-SymbolFiles.ps1
@@ -18,7 +18,7 @@ Write-Progress -Activity $ActivityName -CurrentOperation "Discovery PDB files"
 $PDBs = Get-ChildItem -rec "$Path/*.pdb"
 
 # Filter PDBs to product OR test related.
-$testregex = "unittest|tests|\.test\."
+$testregex = "unittest|tests|\.test\.|Test"
 
 Write-Progress -Activity $ActivityName -CurrentOperation "De-duplicating symbols"
 $PDBsByHash = @{}

--- a/azure-pipelines/archive-sourcecode.yml
+++ b/azure-pipelines/archive-sourcecode.yml
@@ -63,7 +63,16 @@ extends:
         - powershell: azure-pipelines/variables/_pipelines.ps1
           failOnStderr: true
           displayName: ⚙ Set pipeline variables based on source
-        - powershell: >
+        - task: AzureCLI@2
+          displayName: 🔏 Authenticate with WIF service connection
+          inputs:
+            azureSubscription: VS Core Source Code Archival
+            scriptType: pscore
+            scriptLocation: inlineScript
+            inlineScript: |
+              $accessToken = az account get-access-token --query accessToken --resource api://177cf50a-4bf5-4481-8b7e-f32900dfc8e6 -o tsv
+              Write-Host "##vso[task.setvariable variable=scaToken;issecret=true]$accessToken"
+        - pwsh: >
             $TeamAlias = '$(TeamEmail)'.Substring(0, '$(TeamEmail)'.IndexOf('@'))
 
             azure-pipelines/Archive-SourceCode.ps1
@@ -73,6 +82,7 @@ extends:
             -ProductName '$(SymbolsFeatureName)'
             -ProductLanguage English
             -Notes '${{ parameters.notes }}'
+            -AccessToken '$(scaToken)'
             -Verbose
             -WhatIf:$${{ parameters.whatif }}
           displayName: 🗃️ Submit archival request

--- a/azure-pipelines/microbuild.after.yml
+++ b/azure-pipelines/microbuild.after.yml
@@ -11,7 +11,7 @@ steps:
   displayName: 🔍 Verify Signed Files
   inputs:
     TargetFolders: |
-      $(Build.SourcesDirectory)/bin/Packages/$(BuildConfiguration)/NuGet
+      $(Build.SourcesDirectory)/bin/Packages/$(BuildConfiguration)
   condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - ${{ if parameters.IsOptProf }}:

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -41,10 +41,6 @@ parameters:
 - name: EnableAPIScan
   displayName: Include APIScan with compliance tools
   type: boolean
-  default: true
-- name: EnableAPIScan
-  displayName: Include APIScan with compliance tools
-  type: boolean
   default: true # enable in individual repos only AFTER updating TSAOptions.json with your own values
 
 resources:

--- a/azure-pipelines/prepare-insertion-stages.yml
+++ b/azure-pipelines/prepare-insertion-stages.yml
@@ -65,6 +65,10 @@ stages:
         parameters:
           wifServiceConnectionName: azure-public/vside package push
           deadPATServiceConnectionId: 42175e93-c771-4a4f-a132-3cca78f44b3b # azure-public/vssdk
+      - template: WIFtoPATauth.yml
+        parameters:
+          wifServiceConnectionName: azure-public/vside package push
+          deadPATServiceConnectionId: 52ae7e6c-4251-4fe5-9ef1-0e59cecf0e84 # azure-public/vssdk NPM
       - template: npm_push.yml
         parameters:
           tgzDir: $(Pipeline.Workspace)/deployables-Windows/npm

--- a/src/AssemblyInfo.vb
+++ b/src/AssemblyInfo.vb
@@ -1,0 +1,6 @@
+' Copyright (c) Microsoft Corporation. All rights reserved.
+' Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+Imports System.Runtime.InteropServices
+
+<Assembly: DefaultDllImportSearchPaths(DllImportSearchPath.SafeDirectories)>

--- a/src/Directory.Build.targets
+++ b/src/Directory.Build.targets
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.cs" Condition=" '$(Language)'=='C#' " />
+    <Compile Include="$(MSBuildThisFileDirectory)AssemblyInfo.vb" Condition=" '$(Language)'=='VB' " />
   </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />


### PR DESCRIPTION
- Bump powershell from 7.4.2 to 7.4.3 (#275)
- Authenticate source code archival requests
- Check for signed binaries in a broader scoped path
- Ignore .sarif files
- Add support for VB.NET projects
- Fix template expansion
- Fix copyright notice
- Fix bad merge
