### PR TITLE
Avoid `ImmutableArray<T>` in MEF types

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -17,7 +17,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="$(CodefixTestingVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" Version="$(CodefixTestingVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.10.37" />
+    <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.12.15-preview" />
     <PackageVersion Include="Microsoft.VisualStudio.RpcContracts" Version="17.10.21" />
     <PackageVersion Include="Microsoft.VisualStudio.Utilities" Version="17.10.40170" />
     <PackageVersion Include="Microsoft.VisualStudio.Utilities.Testing" Version="17.5.33627.172" />

--- a/src/Microsoft.ServiceHub.Framework/Container/ExportBrokeredServiceAttribute.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/ExportBrokeredServiceAttribute.cs
@@ -142,7 +142,7 @@ internal interface IBrokeredServicesExportMetadata
 
 	/// <inheritdoc cref="ExportBrokeredServiceAttribute.OptionalInterfacesImplemented"/>
 	[DefaultValue(null)]
-	ImmutableArray<string>[]? OptionalInterfacesImplemented { get; }
+	string[]?[]? OptionalInterfacesImplemented { get; }
 
 	/// <inheritdoc cref="ExportBrokeredServiceAttribute.Audience"/>
 	ServiceAudience[] Audience { get; }

--- a/src/Microsoft.ServiceHub.Framework/Container/ExportBrokeredServiceAttribute.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/ExportBrokeredServiceAttribute.cs
@@ -53,7 +53,7 @@ public class ExportBrokeredServiceAttribute : ExportAttribute
 
 		// We must render this as an array of strings so that when the metadata is read back from the MEF cache,
 		// it doesn't require loading the assembly that declares the optional interface.
-		this.OptionalInterfacesImplemented = optionalInterfaces.Select(t => t.AssemblyQualifiedName!).ToImmutableArray();
+		this.OptionalInterfacesImplemented = optionalInterfaces.Select(t => t.AssemblyQualifiedName!).ToArray();
 	}
 
 	/// <summary>
@@ -70,7 +70,7 @@ public class ExportBrokeredServiceAttribute : ExportAttribute
 	/// Gets an array of <see cref="Type.AssemblyQualifiedName">assembly-qualified names</see> of <em>optional</em> interfaces
 	/// that the exported brokered service implements.
 	/// </summary>
-	public ImmutableArray<string> OptionalInterfacesImplemented { get; } = ImmutableArray<string>.Empty;
+	public string[] OptionalInterfacesImplemented { get; } = [];
 
 	/// <summary>
 	/// Gets or sets a value indicating which clients should be allowed to directly acquire this service.

--- a/src/Microsoft.ServiceHub.Framework/Container/ServiceBrokerOfExportedServices.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/ServiceBrokerOfExportedServices.cs
@@ -304,7 +304,7 @@ public abstract class ServiceBrokerOfExportedServices : IServiceBroker
 				{
 					ServiceRegistration registration = new(exportMetadata.Audience[i], null, exportMetadata.AllowTransitiveGuestClients[i])
 					{
-						AdditionalServiceInterfaceTypeNames = exportMetadata.OptionalInterfacesImplemented?[i] is { IsDefault: false } ifaces ? ifaces : ImmutableArray<string>.Empty,
+						AdditionalServiceInterfaceTypeNames = exportMetadata.OptionalInterfacesImplemented?[i] is string?[] ifaces ? ifaces.ToImmutableArray() : ImmutableArray<string>.Empty,
 					};
 					registrations.Add(moniker, registration);
 				}

--- a/src/Microsoft.ServiceHub.Framework/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.ServiceHub.Framework/PublicAPI.Unshipped.txt
@@ -2,7 +2,7 @@ Microsoft.ServiceHub.Framework.ServiceJsonRpcDescriptor.AdditionalServiceInterfa
 Microsoft.ServiceHub.Framework.ServiceJsonRpcDescriptor.JsonRpcConnection.JsonRpcConnection(StreamJsonRpc.JsonRpc! jsonRpc, Microsoft.ServiceHub.Framework.ServiceJsonRpcDescriptor? owner) -> void
 Microsoft.ServiceHub.Framework.ServiceJsonRpcDescriptor.WithAdditionalServiceInterfaces(System.Collections.Immutable.ImmutableArray<System.Type!>? value) -> Microsoft.ServiceHub.Framework.ServiceJsonRpcDescriptor!
 Microsoft.VisualStudio.Shell.ServiceBroker.ExportBrokeredServiceAttribute.ExportBrokeredServiceAttribute(string! name, string? version, params System.Type![]! optionalInterfaces) -> void
-Microsoft.VisualStudio.Shell.ServiceBroker.ExportBrokeredServiceAttribute.OptionalInterfacesImplemented.get -> System.Collections.Immutable.ImmutableArray<string!>
+Microsoft.VisualStudio.Shell.ServiceBroker.ExportBrokeredServiceAttribute.OptionalInterfacesImplemented.get -> string![]!
 Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.TraceEvents.AdditionalProxyInterfaceTypeLoadFailure = 5 -> Microsoft.VisualStudio.Utilities.ServiceBroker.GlobalBrokeredServiceContainer.TraceEvents
 Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceRegistration.AdditionalServiceInterfaceTypeNames.get -> System.Collections.Immutable.ImmutableArray<string!>
 Microsoft.VisualStudio.Utilities.ServiceBroker.ServiceRegistration.AdditionalServiceInterfaceTypeNames.init -> void

--- a/test/Microsoft.ServiceHub.Framework.Tests/Container/ExportedBrokeredServiceTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/Container/ExportedBrokeredServiceTests.cs
@@ -7,6 +7,7 @@ using Microsoft;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.ServiceHub.Framework.Services;
 using Microsoft.ServiceHub.Framework.Testing;
+using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
 using Xunit;
 using Xunit.Abstractions;
@@ -227,6 +228,14 @@ public class ExportedBrokeredServiceTests : TestBase, IAsyncLifetime
 		{
 			(svc as IDisposable)?.Dispose();
 		}
+	}
+
+	[Fact]
+	public async Task CompositionIsSerializable()
+	{
+		ComposableCatalog catalog = await MefHost.GetCatalogAsync(this.TimeoutToken);
+		CachedCatalog cachedCatalog = new CachedCatalog();
+		await cachedCatalog.SaveAsync(catalog, Stream.Null, this.TimeoutToken);
 	}
 
 	[ExportBrokeredService("Calculator", "1.0")]

--- a/test/Microsoft.ServiceHub.Framework.Tests/Mocks/MefHost.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/Mocks/MefHost.cs
@@ -6,18 +6,19 @@ using Microsoft.VisualStudio.Composition;
 using Microsoft.VisualStudio.Threading;
 using Microsoft.VisualStudio.Utilities.ServiceBroker;
 
-internal class MefHost
+internal class MefHost(bool serializedCatalog = false)
 {
-	private static readonly AsyncLazy<ComposableCatalog> Catalog = new(CreateCatalogAsync);
-	private static readonly AsyncLazy<IExportProviderFactory> ExportProviderFactory = new(() => CreateExportProviderFactoryAsync(CancellationToken.None), null);
+	private static readonly AsyncLazy<ComposableCatalog> Catalog = new(() => CreateCatalogAsync(serialized: false, CancellationToken.None));
+	private static readonly AsyncLazy<ComposableCatalog> SerializedCatalog = new(() => CreateCatalogAsync(serialized: true, CancellationToken.None));
+
+	private static readonly AsyncLazy<IExportProviderFactory> ExportProviderFactory = new(() => CreateExportProviderFactoryAsync(serialized: false, CancellationToken.None), null);
+	private static readonly AsyncLazy<IExportProviderFactory> SerializedExportProviderFactory = new(() => CreateExportProviderFactoryAsync(serialized: true, CancellationToken.None), null);
 
 	internal GlobalBrokeredServiceContainer? BrokeredServiceContainer { get; set; }
 
-	internal static Task<ComposableCatalog> GetCatalogAsync(CancellationToken cancellationToken) => Catalog.GetValueAsync(cancellationToken);
-
 	internal async ValueTask<ExportProvider> CreateExportProviderAsync(CancellationToken cancellationToken = default)
 	{
-		IExportProviderFactory exportProviderFactory = await ExportProviderFactory.GetValueAsync(cancellationToken);
+		IExportProviderFactory exportProviderFactory = await (serializedCatalog ? SerializedExportProviderFactory : ExportProviderFactory).GetValueAsync(cancellationToken);
 		ExportProvider exportProvider = exportProviderFactory.CreateExportProvider();
 
 		// Bootstrap brokered services
@@ -31,15 +32,28 @@ internal class MefHost
 		return exportProvider;
 	}
 
-	private static async Task<IExportProviderFactory> CreateExportProviderFactoryAsync(CancellationToken cancellationToken)
+	private static async Task<IExportProviderFactory> CreateExportProviderFactoryAsync(bool serialized, CancellationToken cancellationToken)
 	{
-		ComposableCatalog catalog = await Catalog.GetValueAsync(cancellationToken);
-		CompositionConfiguration configuration = CompositionConfiguration.Create(catalog);
-		configuration.ThrowOnErrors();
-		return configuration.CreateExportProviderFactory();
+		if (serialized)
+		{
+			ComposableCatalog catalog = await SerializedCatalog.GetValueAsync(cancellationToken);
+			CompositionConfiguration configuration = CompositionConfiguration.Create(catalog);
+			CachedComposition cachedComposition = new();
+			MemoryStream ms = new();
+			await cachedComposition.SaveAsync(configuration, ms, cancellationToken);
+			ms.Position = 0;
+			return await cachedComposition.LoadExportProviderFactoryAsync(ms, Resolver.DefaultInstance, cancellationToken);
+		}
+		else
+		{
+			ComposableCatalog catalog = await Catalog.GetValueAsync(cancellationToken);
+			CompositionConfiguration configuration = CompositionConfiguration.Create(catalog);
+			configuration.ThrowOnErrors();
+			return configuration.CreateExportProviderFactory();
+		}
 	}
 
-	private static async Task<ComposableCatalog> CreateCatalogAsync()
+	private static async Task<ComposableCatalog> CreateCatalogAsync(bool serialized, CancellationToken cancellationToken)
 	{
 		PartDiscovery discovery = PartDiscovery.Combine(
 			new AttributedPartDiscovery(Resolver.DefaultInstance, isNonPublicSupported: true),
@@ -49,8 +63,18 @@ internal class MefHost
 			typeof(GlobalBrokeredServiceContainer).Assembly,
 			typeof(MefHost).Assembly,
 		};
-		DiscoveredParts parts = await discovery.CreatePartsAsync(catalogAssemblies);
+		DiscoveredParts parts = await discovery.CreatePartsAsync(catalogAssemblies, cancellationToken: cancellationToken);
 		ComposableCatalog catalog = ComposableCatalog.Create(Resolver.DefaultInstance).AddParts(parts);
+
+		if (serialized)
+		{
+			CachedCatalog cachedCatalog = new CachedCatalog();
+			MemoryStream ms = new();
+			await cachedCatalog.SaveAsync(catalog, ms, cancellationToken);
+			ms.Position = 0;
+			catalog = await cachedCatalog.LoadAsync(ms, Resolver.DefaultInstance, cancellationToken);
+		}
+
 		return catalog;
 	}
 }


### PR DESCRIPTION
The `ImmutableArray<string>` type isn't supported by the VS-MEF cache serialization code. We need to use the more ordinary `string[]` type.

I added more exhaustive MEF testing (including serialization) which turned out to be critical because it found [a bug in VS-MEF][1] that would block this scenario.

[1]: https://github.com/microsoft/vs-mef/pull/508