### PR TITLE
Add support for MEF exported brokered services with null versions

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/Container/IExportedBrokeredService.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/IExportedBrokeredService.cs
@@ -16,13 +16,19 @@ public interface IExportedBrokeredService
 	/// Gets the <see cref="ServiceRpcDescriptor"/> to be used when activating the service.
 	/// </summary>
 	/// <remarks>
+	/// <para>
 	/// When a brokered service supports multiple versions in their <see cref="ServiceMoniker"/>,
 	/// it may be important to consider the version being activated to know which <see cref="ServiceRpcDescriptor"/> to return
 	/// from this property.
 	/// This <see cref="ServiceMoniker"/> may be imported via MEF in the same MEF part that implements this interface
 	/// in order to check the value before returning from this property getter.
+	/// </para>
+	/// <para>
+	/// This property may return <see langword="null"/> when the brokered service does not support the version of the service requested by the client.
+	/// This will result in the client receiving <see langword="null" /> instead of a service instance.
+	/// </para>
 	/// </remarks>
-	ServiceRpcDescriptor Descriptor { get; }
+	ServiceRpcDescriptor? Descriptor { get; }
 
 	/// <summary>
 	/// Initializes the brokered service before returning the new instance to its client.
@@ -34,6 +40,8 @@ public interface IExportedBrokeredService
 	/// similar to what <see cref="BrokeredServiceFactory"/> would have allowed for when proffering a non-MEF
 	/// brokered service with <see cref="IBrokeredServiceContainer.Proffer(ServiceRpcDescriptor, BrokeredServiceFactory)"/>.
 	/// Empty methods may simply return <see cref="Task.CompletedTask"/>.</para>
+	/// <para>Throwing from this method will lead to the client experiencing a <see cref="ServiceActivationFailedException"/>
+	/// with the exception thrown from here preserved as an inner exception.</para>
 	/// </remarks>
 	[JsonRpcIgnore]
 	Task InitializeAsync(CancellationToken cancellationToken);

--- a/src/Microsoft.ServiceHub.Framework/Container/ServiceBrokerForExportedBrokeredServices.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/ServiceBrokerForExportedBrokeredServices.cs
@@ -148,16 +148,35 @@ internal class ServiceBrokerForExportedBrokeredServices : IServiceBroker, IDispo
 		Verify.Operation(this.ActivatedMoniker is not null, "Exporting properties must be set first.");
 
 		string? requiredVersion = this.ActivatedMoniker.Version?.ToString();
+		Lazy<IExportedBrokeredService, IBrokeredServicesExportMetadata>? nullVersionedFactory = null;
+
+		// First search for an exact version match.
 		foreach (Lazy<IExportedBrokeredService, IBrokeredServicesExportMetadata> factory in this.Helper.ExportedBrokeredServices)
 		{
 			for (int i = 0; i < factory.Metadata.ServiceName.Length; i++)
 			{
-				if (this.ActivatedMoniker.Name == factory.Metadata.ServiceName[i] && requiredVersion == factory.Metadata.ServiceVersion[i])
+				if (this.ActivatedMoniker.Name == factory.Metadata.ServiceName[i])
 				{
-					Verify.Operation(!factory.IsValueCreated, "This method should only be called once.");
-					return factory.Value;
+					if (requiredVersion == factory.Metadata.ServiceVersion[i])
+					{
+						Verify.Operation(!factory.IsValueCreated, "This method should only be called once.");
+						return factory.Value;
+					}
+
+					if (factory.Metadata.ServiceVersion[i] is null)
+					{
+						// Remember this in case we don't find an exact version match.
+						nullVersionedFactory = factory;
+					}
 				}
 			}
+		}
+
+		// Fallback to the catch-all version if we found one.
+		if (nullVersionedFactory is not null)
+		{
+			Verify.Operation(!nullVersionedFactory.IsValueCreated, "This method should only be called once.");
+			return nullVersionedFactory.Value;
 		}
 
 		return null;

--- a/src/Microsoft.ServiceHub.Framework/PublicAPI.Shipped.txt
+++ b/src/Microsoft.ServiceHub.Framework/PublicAPI.Shipped.txt
@@ -341,7 +341,7 @@ Microsoft.VisualStudio.Shell.ServiceBroker.IBrokeredServiceContainerInternal
 Microsoft.VisualStudio.Shell.ServiceBroker.IBrokeredServiceContainerInternal.GetLimitedAccessServiceBroker(Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience audience, System.Collections.Generic.IReadOnlyDictionary<string!, string!>! clientCredentials, Microsoft.VisualStudio.Shell.ServiceBroker.ClientCredentialsPolicy credentialPolicy) -> Microsoft.ServiceHub.Framework.IServiceBroker!
 Microsoft.VisualStudio.Shell.ServiceBroker.IBrokeredServiceContainerInternal.LocalUserCredentials.get -> System.Collections.Generic.IReadOnlyDictionary<string!, string!>!
 Microsoft.VisualStudio.Shell.ServiceBroker.IExportedBrokeredService
-Microsoft.VisualStudio.Shell.ServiceBroker.IExportedBrokeredService.Descriptor.get -> Microsoft.ServiceHub.Framework.ServiceRpcDescriptor!
+Microsoft.VisualStudio.Shell.ServiceBroker.IExportedBrokeredService.Descriptor.get -> Microsoft.ServiceHub.Framework.ServiceRpcDescriptor?
 Microsoft.VisualStudio.Shell.ServiceBroker.IExportedBrokeredService.InitializeAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task!
 Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience
 Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience.AllClientsIncludingGuests = Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience.Local | Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience.RemoteExclusiveClient | Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience.LiveShareGuest -> Microsoft.VisualStudio.Shell.ServiceBroker.ServiceAudience

--- a/test/Microsoft.ServiceHub.Framework.Tests/Container/ExportedBrokeredServiceTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/Container/ExportedBrokeredServiceTests.cs
@@ -22,7 +22,7 @@ public class ExportedBrokeredServiceTests : TestBase, IAsyncLifetime
 
 	private interface ICalculator
 	{
-		ValueTask<MockService> GetThisAsync();
+		ValueTask<ICalculator> GetThisAsync();
 
 		ValueTask<int> AddAsync(int a, int b);
 	}
@@ -96,7 +96,7 @@ public class ExportedBrokeredServiceTests : TestBase, IAsyncLifetime
 		using (calc as IDisposable)
 		{
 			Assumes.Present(calc);
-			realObject = await calc.GetThisAsync();
+			realObject = (MockService)await calc.GetThisAsync();
 			Assert.Equal(1, realObject.InitializeInvocationCount);
 		}
 
@@ -111,7 +111,7 @@ public class ExportedBrokeredServiceTests : TestBase, IAsyncLifetime
 		using (calc as IDisposable)
 		{
 			Assumes.Present(calc);
-			realObject = await calc.GetThisAsync();
+			realObject = (MockService)await calc.GetThisAsync();
 			Assert.Equal(0, realObject.DisposalInvocationCount);
 		}
 
@@ -128,7 +128,7 @@ public class ExportedBrokeredServiceTests : TestBase, IAsyncLifetime
 		using (calc as IDisposable)
 		{
 			Assumes.Present(calc);
-			realObject = await calc.GetThisAsync();
+			realObject = (MockService)await calc.GetThisAsync();
 			Assert.Equal(0, realObject.DisposalInvocationCount);
 		}
 
@@ -149,17 +149,71 @@ public class ExportedBrokeredServiceTests : TestBase, IAsyncLifetime
 		using (calc as IDisposable)
 		{
 			Assumes.Present(calc);
-			realObject1 = await calc.GetThisAsync();
+			realObject1 = (MockService)await calc.GetThisAsync();
 		}
 
 		calc = await this.ServiceBroker.GetProxyAsync<ICalculator>(MockService.SharedDescriptor);
 		using (calc as IDisposable)
 		{
 			Assumes.Present(calc);
-			realObject2 = await calc.GetThisAsync();
+			realObject2 = (MockService)await calc.GetThisAsync();
 		}
 
 		Assert.NotSame(realObject1, realObject2);
+	}
+
+	[Fact]
+	public async Task NullVersion_NullDescriptor_GetPipe()
+	{
+		NullVersionedCalculator.CreatedInstances.Clear();
+		IDuplexPipe? calc = await this.ServiceBroker.GetPipeAsync(new ServiceMoniker("Calculator", new Version(9, 0)));
+		Assert.Null(calc);
+		Assert.True(Assert.Single(NullVersionedCalculator.CreatedInstances).IsDisposed);
+	}
+
+	[Fact]
+	public async Task NullVersion_NonNullDescriptor_GetPipe()
+	{
+		NullVersionedCalculator.CreatedInstances.Clear();
+		IDuplexPipe? calc = await this.ServiceBroker.GetPipeAsync(new ServiceMoniker("Calculator", new Version(8, 0)));
+		Assert.NotNull(calc);
+		Assert.Single(NullVersionedCalculator.CreatedInstances);
+	}
+
+	[Fact]
+	public async Task NullVersion_NonNullDescriptor_GetPipe_NullVersion()
+	{
+		NullVersionedCalculator.CreatedInstances.Clear();
+		IDuplexPipe? calc = await this.ServiceBroker.GetPipeAsync(new ServiceMoniker("Calculator", null));
+		Assert.NotNull(calc);
+		Assert.Single(NullVersionedCalculator.CreatedInstances);
+	}
+
+	[Fact]
+	public async Task NullVersion_NullDescriptor_GetProxy()
+	{
+		NullVersionedCalculator.CreatedInstances.Clear();
+		ICalculator? calc = await this.ServiceBroker.GetProxyAsync<ICalculator>(NullVersionedCalculator.CreateDescriptor(new Version(9, 0)));
+		Assert.Null(calc);
+		Assert.True(Assert.Single(NullVersionedCalculator.CreatedInstances).IsDisposed);
+	}
+
+	[Fact]
+	public async Task NullVersion_NonNullDescriptor_GetProxy()
+	{
+		NullVersionedCalculator.CreatedInstances.Clear();
+		ICalculator? calc = await this.ServiceBroker.GetProxyAsync<ICalculator>(NullVersionedCalculator.CreateDescriptor(new Version(8, 0)));
+		Assert.NotNull(calc);
+		Assert.Single(NullVersionedCalculator.CreatedInstances);
+	}
+
+	[Fact]
+	public async Task NullVersion_NonNullDescriptor_GetProxy_NullVersion()
+	{
+		NullVersionedCalculator.CreatedInstances.Clear();
+		ICalculator? calc = await this.ServiceBroker.GetProxyAsync<ICalculator>(NullVersionedCalculator.CreateDescriptor(null));
+		Assert.NotNull(calc);
+		Assert.Single(NullVersionedCalculator.CreatedInstances);
 	}
 
 	[Theory, CombinatorialData]
@@ -220,7 +274,7 @@ public class ExportedBrokeredServiceTests : TestBase, IAsyncLifetime
 
 		internal int DisposalInvocationCount { get; private set; }
 
-		public ValueTask<MockService> GetThisAsync() => new(this);
+		public ValueTask<ICalculator> GetThisAsync() => new(this);
 
 		public ValueTask<int> AddAsync(int a, int b) => new(a + b);
 
@@ -303,5 +357,50 @@ public class ExportedBrokeredServiceTests : TestBase, IAsyncLifetime
 			this.Callback?.Invoke(message);
 			return Task.CompletedTask;
 		}
+	}
+
+	[ExportBrokeredService("Calculator", null)]
+	private class NullVersionedCalculator : IExportedBrokeredService, ICalculator, IDisposable
+	{
+		internal static readonly Queue<NullVersionedCalculator> CreatedInstances = new();
+
+		private NullVersionedCalculator()
+		{
+			CreatedInstances.Enqueue(this);
+		}
+
+		public ServiceRpcDescriptor? Descriptor => this.ServiceMoniker.Version switch
+		{
+			null or { Major: 8 } => CreateDescriptor(this.ServiceMoniker.Version),
+			_ => null,
+		};
+
+		internal bool IsDisposed { get; private set; }
+
+		[Import]
+		private ServiceMoniker ServiceMoniker { get; set; } = null!;
+
+		public ValueTask<int> AddAsync(int a, int b)
+		{
+			throw new NotImplementedException();
+		}
+
+		public void Dispose()
+		{
+			this.IsDisposed = true;
+		}
+
+		public ValueTask<ICalculator> GetThisAsync()
+		{
+			throw new NotImplementedException();
+		}
+
+		public Task InitializeAsync(CancellationToken cancellationToken)
+		{
+			return Task.CompletedTask;
+		}
+
+		internal static ServiceRpcDescriptor CreateDescriptor(Version? version) =>
+			new ServiceJsonRpcDescriptor(new ServiceMoniker("Calculator", version), ServiceJsonRpcDescriptor.Formatters.UTF8, ServiceJsonRpcDescriptor.MessageDelimiters.HttpLikeHeaders);
 	}
 }


### PR DESCRIPTION
Null versioned services are supposed to serve as a "catch-all" for any version the client might request. This worked for VSPackage-proffered services, but MEF exported services failed to be activated with arbitrary versions. This change corrects that.

This change also enables exported brokered services to "reject" requests by returning a null descriptor, which is important with catch-all versioning so that unknown versions can be rejected at runtime.