### PR TITLE
Suppress localization for new projects that don't need it

### DIFF
--- a/src/Microsoft.ServiceHub.Analyzers.CSharp/Microsoft.ServiceHub.Analyzers.CSharp.csproj
+++ b/src/Microsoft.ServiceHub.Analyzers.CSharp/Microsoft.ServiceHub.Analyzers.CSharp.csproj
@@ -7,6 +7,9 @@
     <IsPackable>false</IsPackable>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IsAnalyzerProject>true</IsAnalyzerProject>
+
+    <!-- We do not (yet) have any resx files. -->
+    <MicroBuild_LocalizeOutputAssembly>false</MicroBuild_LocalizeOutputAssembly>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.ServiceHub.Analyzers.CodeFixes/Microsoft.ServiceHub.Analyzers.CodeFixes.csproj
+++ b/src/Microsoft.ServiceHub.Analyzers.CodeFixes/Microsoft.ServiceHub.Analyzers.CodeFixes.csproj
@@ -15,6 +15,9 @@
     <IsAnalyzerProject>true</IsAnalyzerProject>
 
     <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);PackBuildOutputs</TargetsForTfmSpecificContentInPackage>
+
+    <!-- We do not (yet) have any resx files. -->
+    <MicroBuild_LocalizeOutputAssembly>false</MicroBuild_LocalizeOutputAssembly>
   </PropertyGroup>
 
   <Target Name="PackBuildOutputs" DependsOnTargets="ResolveProjectReferences;SatelliteDllsProjectOutputGroup;SatelliteDllsProjectOutputGroupDependencies">

--- a/src/Microsoft.ServiceHub.Analyzers.VisualBasic/Microsoft.ServiceHub.Analyzers.VisualBasic.csproj
+++ b/src/Microsoft.ServiceHub.Analyzers.VisualBasic/Microsoft.ServiceHub.Analyzers.VisualBasic.csproj
@@ -7,6 +7,9 @@
     <IsPackable>false</IsPackable>
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
     <IsAnalyzerProject>true</IsAnalyzerProject>
+
+    <!-- We do not (yet) have any resx files. -->
+    <MicroBuild_LocalizeOutputAssembly>false</MicroBuild_LocalizeOutputAssembly>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This fixes build warnings that appear as build breaks in the official build.