### PR TITLE
Fix dependencies in non-analyzer packages

### DIFF
--- a/src/Microsoft.ServiceHub.Analyzers.CodeFixes/Microsoft.ServiceHub.Analyzers.CodeFixes.csproj
+++ b/src/Microsoft.ServiceHub.Analyzers.CodeFixes/Microsoft.ServiceHub.Analyzers.CodeFixes.csproj
@@ -42,4 +42,15 @@
     <ProjectReference Include="..\Microsoft.ServiceHub.Analyzers\Microsoft.ServiceHub.Analyzers.csproj" />
   </ItemGroup>
 
+  <ItemDefinitionGroup>
+    <!-- These are necessary in spite of SuppressDependenciesWhenPacking=true above
+         so that projects that reference this one also do not pick these up as dependencies. -->
+    <PackageReference>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <ProjectReference>
+      <PrivateAssets>all</PrivateAssets>
+    </ProjectReference>
+  </ItemDefinitionGroup>
+  
 </Project>

--- a/src/Microsoft.ServiceHub.Framework/Microsoft.ServiceHub.Framework.csproj
+++ b/src/Microsoft.ServiceHub.Framework/Microsoft.ServiceHub.Framework.csproj
@@ -21,7 +21,7 @@
     <AdditionalFiles Include="PublicAPI.Unshipped.txt" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.ServiceHub.Analyzers\Microsoft.ServiceHub.Analyzers.csproj" PrivateAssets="none" />
+    <ProjectReference Include="..\Microsoft.ServiceHub.Analyzers.CodeFixes\Microsoft.ServiceHub.Analyzers.CodeFixes.csproj" PrivateAssets="none" />
   </ItemGroup>
 
   <Import Project="..\OptProf.targets" />


### PR DESCRIPTION
This corrects an errant package dependency on a non-existing `Microsoft.ServiceHub.Analyzers.Only` package that occurred because the `Microsoft.ServiceHub.Framework` project was referencing the analyzer project instead of the codefixes project.

It also fixes a bunch of extra `Microsoft.CodeAnalysis.*` package dependencies that showed up in `Microsoft.ServiceHub.Framework`.