### PR TITLE
Fix break in C# projects using our analyzers

### DIFF
--- a/src/Microsoft.ServiceHub.Analyzers/AbstractISB004OptionalInterfacesMustBeImplementedAnalyzer.cs
+++ b/src/Microsoft.ServiceHub.Analyzers/AbstractISB004OptionalInterfacesMustBeImplementedAnalyzer.cs
@@ -3,7 +3,6 @@
 
 namespace Microsoft.ServiceHub.Analyzers;
 
-[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
 public abstract class AbstractISB004OptionalInterfacesMustBeImplementedAnalyzer : DiagnosticAnalyzer
 {
 	public const string Id = "ISB004";


### PR DESCRIPTION
The `DiagnosticAnalyzer` attribute should only be present on the concrete derived classes for an abstract analyzer class.