### PR TITLE
Bump Nerdbank.Streams to 2.11.79

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -33,7 +33,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(VSThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VSThreadingVersion)" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.106" />
-    <PackageVersion Include="Nerdbank.Streams" Version="2.11.74" />
+    <PackageVersion Include="Nerdbank.Streams" Version="2.11.79" />
     <PackageVersion Include="NuGet.Protocol" Version="6.10.1" />
     <PackageVersion Include="StreamJsonRpc" Version="2.20.7-beta" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />

--- a/src/servicebroker-npm/package.json
+++ b/src/servicebroker-npm/package.json
@@ -30,7 +30,7 @@
 		"caught": "^0.1.3",
 		"immutable": "^4.3.1",
 		"msgpack-lite": "^0.1.26",
-		"nerdbank-streams": "^2.10.69",
+		"nerdbank-streams": "^2.11.79",
 		"strict-event-emitter-types": "^2.0.0",
 		"string-hash": "^1.1.3",
 		"uuid": "^9.0.1",

--- a/src/servicebroker-npm/yarn.lock
+++ b/src/servicebroker-npm/yarn.lock
@@ -854,7 +854,7 @@ __metadata:
     jshint: "npm:^2.13.6"
     msgpack-lite: "npm:^0.1.26"
     nerdbank-gitversioning: "npm:^3.6.133"
-    nerdbank-streams: "npm:^2.10.69"
+    nerdbank-streams: "npm:^2.11.79"
     nyc: "npm:^15.1.0"
     prettier: "npm:^3.0.0"
     q: "npm:^1.5.1"
@@ -5187,15 +5187,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nerdbank-streams@npm:^2.10.69":
-  version: 2.10.72
-  resolution: "nerdbank-streams@npm:2.10.72"
+"nerdbank-streams@npm:^2.11.79":
+  version: 2.11.79
+  resolution: "nerdbank-streams@npm:2.11.79"
   dependencies:
     await-semaphore: "npm:^0.1.3"
     cancellationtoken: "npm:^2.2.0"
     caught: "npm:^0.1.3"
     msgpack-lite: "npm:^0.1.26"
-  checksum: 10/0607075d5698d3adc7db087eb605b55dbe96005d32f28fc3c845f839bf9e3b97e0d7248f8f77a9b2f1bc864a27ad085abfa2e6531ae5f32e97463fbef6a6ecc6
+  checksum: 10/43b773fe78ff3c1008c17fa077321c2b1a8c384e4f51f08bf872f16fd19b62ae7ee9e61fcfc07d7575647a10afdff12675f8007f7417fcac13bee89c3f09b73a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This fixes a brokered service communication blockage that may happen after sending >=16KB of data in a single data packet.

Fixes devdiv-2172913