### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -9,13 +9,13 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.11.3",
+      "version": "17.11.5",
       "commands": [
         "dotnet-coverage"
       ]
     },
     "nbgv": {
-      "version": "3.6.139",
+      "version": "3.6.141",
       "commands": [
         "nbgv"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:8.0.300-jammy
+FROM mcr.microsoft.com/dotnet/sdk:8.0.400-jammy
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <MicroBuildVersion>2.0.162</MicroBuildVersion>
+    <MicroBuildVersion>2.0.165</MicroBuildVersion>
     <CodeAnalysisVersionForAnalyzers>3.11.0</CodeAnalysisVersionForAnalyzers>
     <CodeAnalysisVersion>4.10.0</CodeAnalysisVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>3.11.0-beta1.24324.1</MicrosoftCodeAnalysisAnalyzersVersion>
@@ -28,7 +28,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" Version="17.6.32" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.8.8" />
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(VSThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VSThreadingVersion)" />
@@ -58,7 +58,7 @@
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.139" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.141" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" Condition="'$(DoNotReferenceNullable)'!='true'" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -65,6 +65,11 @@ parameters:
   type: boolean
   default: true
 
+# Whether this is a special one-off build for inserting into VS for a validation insertion PR (that will never be merged).
+- name: ValidationBuild
+  type: boolean
+  default: false
+
 - name: EnableAPIScan
   type: boolean
   default: false
@@ -202,6 +207,7 @@ jobs:
       parameters:
         EnableOptProf: ${{ parameters.EnableOptProf }}
         IsOptProf: ${{ parameters.IsOptProf }}
+        ValidationBuild: ${{ parameters.ValidationBuild }}
 
 - ${{ if not(parameters.IsOptProf) }}:
   - ${{ if parameters.EnableLinuxBuild }}:

--- a/azure-pipelines/microbuild.after.yml
+++ b/azure-pipelines/microbuild.after.yml
@@ -5,14 +5,17 @@ parameters:
 - name: IsOptProf
   type: boolean
   default: false
+- name: ValidationBuild
+  type: boolean
 
 steps:
-- task: MicroBuildCodesignVerify@3
-  displayName: 🔍 Verify Signed Files
-  inputs:
-    TargetFolders: |
-      $(Build.SourcesDirectory)/bin/Packages/$(BuildConfiguration)
-  condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
+- ${{ if not(parameters.ValidationBuild) }}: # skip CodesignVerify on validation builds because we don't even test-sign nupkg's.
+  - task: MicroBuildCodesignVerify@3
+    displayName: 🔍 Verify Signed Files
+    inputs:
+      TargetFolders: |
+        $(Build.SourcesDirectory)/bin/Packages/$(BuildConfiguration)
+    condition: and(succeeded(), eq(variables['Agent.OS'], 'Windows_NT'))
 
 - ${{ if parameters.IsOptProf }}:
   - task: ms-vscs-artifact.build-tasks.artifactDropTask-1.artifactDropTask@0

--- a/azure-pipelines/prepare-insertion-stages.yml
+++ b/azure-pipelines/prepare-insertion-stages.yml
@@ -9,7 +9,6 @@ parameters:
 stages:
 - stage: release
   displayName: Publish
-  condition: and(succeeded(), eq('${{ parameters.RealSign }}', 'true'))
   jobs:
   - ${{ if parameters.ArchiveSymbols }}:
     - job: symbol_archive
@@ -34,7 +33,10 @@ stages:
 
   - ${{ if true }}:
     - job: push
-      displayName: azure-public/vssdk feed
+      ${{ if parameters.RealSign }}:
+        displayName: azure-public/vssdk feed
+      ${{ else }}:
+        displayName: devdiv/vs-impl feed # Leave this as-is, since non-signed builds must not be pushed to public feeds.
       ${{ if parameters.ArchiveSymbols }}:
         dependsOn: symbol_archive
       pool:
@@ -49,8 +51,12 @@ stages:
           packagesToPush: '$(Pipeline.Workspace)/deployables-Windows/NuGet/*.nupkg'
           packageParentPath: $(Pipeline.Workspace)/deployables-Windows/NuGet
           allowPackageConflicts: true
-          nuGetFeedType: external
-          publishFeedCredentials: azure-public/vssdk
+          ${{ if parameters.RealSign }}:
+            nuGetFeedType: external
+            publishFeedCredentials: azure-public/vssdk
+          ${{ else }}:
+            nuGetFeedType: internal
+            publishVstsFeed: vs-impl # Leave this as-is, since non-signed builds must not be pushed to public feeds.
       steps:
       - checkout: none
       - download: current
@@ -61,17 +67,18 @@ stages:
       - download: current
         artifact: deployables-Windows
         displayName: 🔻 Download deployables-Windows artifact
-      - template: WIFtoPATauth.yml
-        parameters:
-          wifServiceConnectionName: azure-public/vside package push
-          deadPATServiceConnectionId: 42175e93-c771-4a4f-a132-3cca78f44b3b # azure-public/vssdk
-      - template: WIFtoPATauth.yml
-        parameters:
-          wifServiceConnectionName: azure-public/vside package push
-          deadPATServiceConnectionId: 52ae7e6c-4251-4fe5-9ef1-0e59cecf0e84 # azure-public/vssdk NPM
-      - template: npm_push.yml
-        parameters:
-          tgzDir: $(Pipeline.Workspace)/deployables-Windows/npm
-          feedName: azure-public/vssdk
-          feedUrl: https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/npm/registry/
-          service_connection: azure-public/vssdk NPM
+      - ${{ if parameters.RealSign }}:
+        - template: WIFtoPATauth.yml
+          parameters:
+            wifServiceConnectionName: azure-public/vside package push
+            deadPATServiceConnectionId: 42175e93-c771-4a4f-a132-3cca78f44b3b # azure-public/vssdk
+        - template: WIFtoPATauth.yml
+          parameters:
+            wifServiceConnectionName: azure-public/vside package push
+            deadPATServiceConnectionId: 52ae7e6c-4251-4fe5-9ef1-0e59cecf0e84 # azure-public/vssdk NPM
+        - template: npm_push.yml
+          parameters:
+            tgzDir: $(Pipeline.Workspace)/deployables-Windows/npm
+            feedName: azure-public/vssdk
+            feedUrl: https://pkgs.dev.azure.com/azure-public/vside/_packaging/vssdk/npm/registry/
+            service_connection: azure-public/vssdk NPM

--- a/azure-pipelines/publish-codecoverage.yml
+++ b/azure-pipelines/publish-codecoverage.yml
@@ -21,9 +21,8 @@ steps:
     continueOnError: true
 - powershell: azure-pipelines/Merge-CodeCoverage.ps1 -Path '$(Pipeline.Workspace)' -OutputFile coveragereport/merged.cobertura.xml -Format Cobertura -Verbose
   displayName: ⚙ Merge coverage
-- task: PublishCodeCoverageResults@1
+- task: PublishCodeCoverageResults@2
   displayName: 📢 Publish code coverage results to Azure DevOps
   inputs:
-    codeCoverageTool: cobertura
     summaryFileLocation: coveragereport/merged.cobertura.xml
     failIfCoverageEmpty: true

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -14,6 +14,8 @@ resources:
 
 variables:
 - template: GlobalVariables.yml
+- name: MicroBuild_NuPkgSigningEnabled
+  value: false # test-signed nuget packages fail to restore in the VS insertion PR validations. Just don't sign the *at all*.
 
 extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
@@ -33,15 +35,25 @@ extends:
       - template: /azure-pipelines/build.yml@self
         parameters:
           Is1ESPT: true
-          RealSign: true
+          RealSign: false
           windowsPool: VSEngSS-MicroBuild2022-1ES
+          linuxPool:
+            name: AzurePipelines-EO
+            demands:
+            - ImageOverride -equals 1ESPT-Ubuntu22.04
+            os: Linux
+          macOSPool:
+            name: Azure Pipelines
+            vmImage: macOS-12
+            os: macOS
           EnableMacOSBuild: false
           RunTests: false
+          ValidationBuild: true
 
     - template: /azure-pipelines/prepare-insertion-stages.yml@self
       parameters:
         ArchiveSymbols: false
-        RealSign: true
+        RealSign: false
 
     - stage: insertion
       displayName: VS insertion
@@ -73,12 +85,13 @@ extends:
           inputs:
             TeamName: $(TeamName)
             TeamEmail: $(TeamEmail)
-            InsertionPayloadName: $(Build.Repository.Name) VALIDATION BUILD $(Build.BuildNumber) ($(Build.SourceBranch)) [Skip-SymbolCheck]
+            InsertionPayloadName: $(Build.Repository.Name) VALIDATION BUILD $(Build.BuildNumber) ($(Build.SourceBranch)) [Skip-SymbolCheck] [Skip-HashCheck] [Skip-SignCheck]
             InsertionDescription: |
               This PR is for **validation purposes only** for !$(System.PullRequest.PullRequestId). **Do not complete**.
             CustomScriptExecutionCommand: src/VSSDK/NuGet/AllowUnstablePackages.ps1
             InsertionBuildPolicy: Request Perf DDRITs
             InsertionReviewers: $(Build.RequestedFor)
+            DraftPR: false # set to true and update InsertionBuildPolicy when we can specify all the validations we want to run (https://dev.azure.com/devdiv/DevDiv/_workitems/edit/2224288)
             AutoCompletePR: false
             ShallowClone: true
         - powershell: |

--- a/azurepipelines-coverage.yml
+++ b/azurepipelines-coverage.yml
@@ -1,0 +1,6 @@
+# https://learn.microsoft.com/azure/devops/pipelines/test/codecoverage-for-pullrequests?view=azure-devops
+coverage:
+  status:
+    comments: on    # add comment to PRs reporting diff in coverage of modified files
+    diff:           # diff coverage is code coverage only for the lines changed in a pull request.
+      target: 70%   # set this to a desired %. Default is 70%

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.300",
+    "version": "8.0.400",
     "rollForward": "patch",
     "allowPrerelease": false
   },


### PR DESCRIPTION
- Update PublishCodeCoverageResults task to v2
- Bump Nerdbank.GitVersioning from 3.6.139 to 3.6.141 (#280)
- Bump nbgv from 3.6.139 to 3.6.141 (#279)
- Bump dotnet-coverage from 17.11.3 to 17.11.5 (#278)
- Bump .NET SDK to 8.0.400
- Post code coverage diff comments for AzDO PRs
- Fix 1ES PT compliance of vs-validation pipeline
- Speed up validation insertions
- Bump MicroBuild to 2.0.165
- Bump Microsoft.NET.Test.Sdk to 17.11
