### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,19 +3,19 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.4.4",
+      "version": "7.4.5",
       "commands": [
         "pwsh"
       ]
     },
     "dotnet-coverage": {
-      "version": "17.11.5",
+      "version": "17.12.3",
       "commands": [
         "dotnet-coverage"
       ]
     },
     "nbgv": {
-      "version": "3.6.141",
+      "version": "3.6.143",
       "commands": [
         "nbgv"
       ]

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -28,7 +28,7 @@
     <PackageVersion Include="Microsoft.VisualStudio.Sdk.TestFramework.Xunit" Version="17.6.32" />
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.8.8" />
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(VSThreadingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VSThreadingVersion)" />
@@ -58,7 +58,7 @@
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.141" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.143" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" Condition="'$(DoNotReferenceNullable)'!='true'" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>

--- a/azure-pipelines/OptProf.yml
+++ b/azure-pipelines/OptProf.yml
@@ -29,6 +29,8 @@ variables:
   value: false # avoid using nice version since we're building a preliminary/unoptimized package
 - name: IsOptProf
   value: true
+- name: MicroBuild_NuPkgSigningEnabled
+  value: false # test-signed nuget packages fail to restore in the VS insertion PR validations. Just don't sign them *at all*.
 
 stages:
 - stage: Library
@@ -40,12 +42,13 @@ stages:
   - template: build.yml
     parameters:
       Is1ESPT: false
-      RealSign: true
+      RealSign: false
       windowsPool: VSEngSS-MicroBuild2022-1ES
       EnableMacOSBuild: false
       ShouldSkipOptimize: ${{ parameters.ShouldSkipOptimize }}
       IsOptProf: true
       RunTests: false
+      SkipCodesignVerify: true
 - stage: QueueVSBuild
   jobs:
   - job: QueueOptProf

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -66,7 +66,7 @@ parameters:
   default: true
 
 # Whether this is a special one-off build for inserting into VS for a validation insertion PR (that will never be merged).
-- name: ValidationBuild
+- name: SkipCodesignVerify
   type: boolean
   default: false
 
@@ -207,7 +207,7 @@ jobs:
       parameters:
         EnableOptProf: ${{ parameters.EnableOptProf }}
         IsOptProf: ${{ parameters.IsOptProf }}
-        ValidationBuild: ${{ parameters.ValidationBuild }}
+        SkipCodesignVerify: ${{ parameters.SkipCodesignVerify }}
 
 - ${{ if not(parameters.IsOptProf) }}:
   - ${{ if parameters.EnableLinuxBuild }}:

--- a/azure-pipelines/microbuild.after.yml
+++ b/azure-pipelines/microbuild.after.yml
@@ -5,11 +5,11 @@ parameters:
 - name: IsOptProf
   type: boolean
   default: false
-- name: ValidationBuild
+- name: SkipCodesignVerify
   type: boolean
 
 steps:
-- ${{ if not(parameters.ValidationBuild) }}: # skip CodesignVerify on validation builds because we don't even test-sign nupkg's.
+- ${{ if not(parameters.SkipCodesignVerify) }}: # skip CodesignVerify on validation builds because we don't even test-sign nupkg's.
   - task: MicroBuildCodesignVerify@3
     displayName: 🔍 Verify Signed Files
     inputs:

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -126,6 +126,3 @@ extends:
               os: macOS
             EnableMacOSBuild: ${{ parameters.EnableMacOSBuild }}
             RunTests: ${{ parameters.RunTests }}
-      - template: /azure-pipelines/prepare-insertion-stages.yml@self
-        parameters:
-          RealSign: false

--- a/azure-pipelines/vs-validation.yml
+++ b/azure-pipelines/vs-validation.yml
@@ -15,7 +15,7 @@ resources:
 variables:
 - template: GlobalVariables.yml
 - name: MicroBuild_NuPkgSigningEnabled
-  value: false # test-signed nuget packages fail to restore in the VS insertion PR validations. Just don't sign the *at all*.
+  value: false # test-signed nuget packages fail to restore in the VS insertion PR validations. Just don't sign them *at all*.
 
 extends:
   template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
@@ -29,7 +29,7 @@ extends:
         DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
         NUGET_PACKAGES: $(Agent.TempDirectory)/.nuget/packages/
         BuildConfiguration: Release
-        ValidationBuild: true
+        SkipCodesignVerify: true
 
       jobs:
       - template: /azure-pipelines/build.yml@self
@@ -48,7 +48,7 @@ extends:
             os: macOS
           EnableMacOSBuild: false
           RunTests: false
-          ValidationBuild: true
+          SkipCodesignVerify: true
 
     - template: /azure-pipelines/prepare-insertion-stages.yml@self
       parameters:


### PR DESCRIPTION
- Bump powershell from 7.4.4 to 7.4.5 (#282)
- Change OptProf to not require real-signing
- Bump Nerdbank.GitVersioning from 3.6.141 to 3.6.143 (#283)
- Bump nbgv from 3.6.141 to 3.6.143 (#284)
- Bump dotnet-coverage from 17.11.5 to 17.12.2 (#285)
- Bump dotnet-coverage from 17.12.2 to 17.12.3 (#288)
- Bump Microsoft.NET.Test.Sdk from 17.11.0 to 17.11.1 (#287)
- Stop pushing test-signed packages from CI
