### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,19 +3,19 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.4.5",
+      "version": "7.4.6",
       "commands": [
         "pwsh"
       ]
     },
     "dotnet-coverage": {
-      "version": "17.12.5",
+      "version": "17.12.6",
       "commands": [
         "dotnet-coverage"
       ]
     },
     "nbgv": {
-      "version": "3.6.143",
+      "version": "3.6.146",
       "commands": [
         "nbgv"
       ]

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Refer to https://hub.docker.com/_/microsoft-dotnet-sdk for available versions
-FROM mcr.microsoft.com/dotnet/sdk:8.0.400-jammy
+FROM mcr.microsoft.com/dotnet/sdk:8.0.402-jammy
 
 # Installing mono makes `dotnet test` work without errors even for net472.
 # But installing it takes a long time, so it's excluded by default.

--- a/.github/workflows/libtemplate-update.yml
+++ b/.github/workflows/libtemplate-update.yml
@@ -1,0 +1,72 @@
+name: Library.Template update
+
+# PREREQUISITE: This workflow requires the repo to be configured to allow workflows to push commits and create pull requests.
+# Visit https://github.com/USER/REPO/settings/actions
+# Under "Workflow permissions", select "Read and write permissions" and check "Allow GitHub Actions to create ...pull requests"
+# Click Save.
+
+on:
+  schedule:
+  - cron: "0 3 * * Mon" # Sun @ 8 or 9 PM Mountain Time (depending on DST)
+  workflow_dispatch:
+
+jobs:
+  merge:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # avoid shallow clone so nbgv can do its work.
+
+    - name: merge
+      shell: pwsh
+      run: |
+        $LibTemplateBranch = & ./azure-pipelines/Get-LibTemplateBasis.ps1 -ErrorIfNotRelated
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+
+        git fetch https://github.com/aarnott/Library.Template $LibTemplateBranch
+        if ($LASTEXITCODE -ne 0) {
+          exit $LASTEXITCODE
+        }
+        $LibTemplateCommit = git rev-parse FETCH_HEAD
+
+        if ((git rev-list FETCH_HEAD ^HEAD --count) -eq 0) {
+          Write-Host "There are no Library.Template updates to merge."
+          exit 0
+        }
+
+        git -c http.extraheader="AUTHORIZATION: bearer $env:GH_TOKEN" push origin -u FETCH_HEAD:refs/heads/auto/libtemplateUpdate
+    - name: pull request
+      shell: pwsh
+      run: |
+        # If there is already an active pull request, don't create a new one.
+        $existingPR = gh pr list -H auto/libtemplateUpdate --json url | ConvertFrom-Json
+        if ($existingPR) {
+          Write-Host "::warning::Skipping pull request creation because one already exists at $($existingPR[0].url)"
+          exit 0
+        }
+
+        $prTitle = "Merge latest Library.Template"
+        $prBody = "This merges the latest features and fixes from [Library.Template's  branch](https://github.com/AArnott/Library.Template/tree/).
+
+        <details>
+        <summary>Merge conflicts?</summary>
+        Resolve merge conflicts locally by carrying out these steps:
+
+        ```
+        git fetch
+        git checkout auto/libtemplateUpdate
+        git merge origin/main
+        # resolve conflicts
+        git commit
+        git push
+        ```
+        </details>
+
+        ⚠️ Do **not** squash this pull request when completing it. You must *merge* it."
+
+        gh pr create -H auto/libtemplateUpdate -b $prBody -t $prTitle
+      env:
+        GH_TOKEN: ${{ github.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ bld/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
 
+# Jetbrains Rider cache directory
+.idea/
+
 # Visual Studio 2017 auto generated files
 Generated\ Files/
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -16,11 +16,15 @@
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(CodeAnalysisVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="$(CodeAnalysisVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="$(CodefixTestingVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit"
+      Version="$(CodefixTestingVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers"
+      Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.PublicApiAnalyzers"
+      Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(CodeAnalysisVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" Version="$(CodefixTestingVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit"
+      Version="$(CodefixTestingVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="17.12.18" />
     <PackageVersion Include="Microsoft.VisualStudio.RpcContracts" Version="17.10.21" />
     <PackageVersion Include="Microsoft.VisualStudio.Utilities" Version="17.10.40170" />
@@ -29,9 +33,11 @@
     <PackageVersion Include="Microsoft.VisualStudio.Validation" Version="17.8.8" />
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping" Version="$(MicroBuildVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Internal.MicroBuild.NonShipping"
+      Version="$(MicroBuildVersion)" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading" Version="$(VSThreadingVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="$(VSThreadingVersion)" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers"
+      Version="$(VSThreadingVersion)" />
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.106" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.11.79" />
     <PackageVersion Include="NuGet.Protocol" Version="6.10.1" />
@@ -48,18 +54,24 @@
   <ItemGroup Condition="'$(IsAnalyzerProject)'=='true'">
     <!-- Analyzers need to use older references to work in existing C# compilers. -->
     <PackageVersion Update="Microsoft.CodeAnalysis" Version="$(CodeAnalysisVersionForAnalyzers)" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.Common" Version="$(CodeAnalysisVersionForAnalyzers)" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersionForAnalyzers)" />
-    <PackageVersion Update="Microsoft.CodeAnalysis.VisualBasic" Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.Common"
+      Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.CSharp"
+      Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Update="Microsoft.CodeAnalysis.VisualBasic"
+      Version="$(CodeAnalysisVersionForAnalyzers)" />
     <PackageVersion Update="System.Collections.Immutable" Version="6.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <GlobalPackageReference Include="Microsoft.CodeAnalysis.ResxSourceGenerator" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
+    <GlobalPackageReference Include="Microsoft.CodeAnalysis.ResxSourceGenerator"
+      Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
     <GlobalPackageReference Include="CSharpIsNullAnalyzer" Version="0.1.593" />
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
-    <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio" Version="$(MicroBuildVersion)" />
-    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.143" />
-    <GlobalPackageReference Include="Nullable" Version="1.3.1" Condition="'$(DoNotReferenceNullable)'!='true'" />
+    <GlobalPackageReference Include="Microsoft.VisualStudio.Internal.MicroBuild.VisualStudio"
+      Version="$(MicroBuildVersion)" />
+    <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.146" />
+    <GlobalPackageReference Include="Nullable" Version="1.3.1"
+      Condition="'$(DoNotReferenceNullable)'!='true'" />
     <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.556" />
   </ItemGroup>
 </Project>

--- a/azure-pipelines/OptProf_part2.yml
+++ b/azure-pipelines/OptProf_part2.yml
@@ -14,6 +14,8 @@ resources:
   - pipeline: DartLab.OptProf
     source: DartLab.OptProf
     branch: main
+    tags:
+    - production
   repositories:
   - repository: DartLabTemplates
     type: git
@@ -22,7 +24,7 @@ resources:
   - repository: DartLabOptProfTemplates
     type: git
     name: DartLab.OptProf
-    ref: refs/heads/main
+    ref: refs/tags/Production
 
 parameters:
 

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -4,6 +4,12 @@ parameters:
 ##### Feel free to adjust their default value as needed.
 
 # Whether this repo uses OptProf to optimize the built binaries.
+# When enabling this, be sure to update these files:
+# - OptProf.targets: InstallationPath and match TestCase selection with what's in the VS repo.
+# - The project file(s) for the libraries to optimize must import OptProf.targets (for multi-targeted projects, only import it for ONE target).
+# - OptProf.yml: Search for LibraryName (or your library's name) and verify that those names are appropriate.
+# - OptProf_part2.yml: Search for LibraryName (or your library's name) and verify that those names are appropriate.
+# and create pipelines for OptProf.yml, OptProf_part2.yml
 - name: EnableOptProf
   type: boolean
   default: true
@@ -94,7 +100,7 @@ parameters:
 - name: macOSPool
   type: object
   default:
-    vmImage: macOS-12
+    vmImage: macOS-14
 
 jobs:
 - job: Windows

--- a/azure-pipelines/dotnet.yml
+++ b/azure-pipelines/dotnet.yml
@@ -8,7 +8,7 @@ parameters:
 
 steps:
 
-- script: dotnet build -t:build,pack --no-restore -c $(BuildConfiguration) -warnaserror /bl:"$(Build.ArtifactStagingDirectory)/build_logs/build.binlog"
+- script: dotnet build -t:build,pack --no-restore -c $(BuildConfiguration) -warnAsError -warnNotAsError:NU1901,NU1902,NU1903,NU1904 /bl:"$(Build.ArtifactStagingDirectory)/build_logs/build.binlog"
   displayName: 🛠 dotnet build
 
 - ${{ if not(parameters.IsOptProf) }}:

--- a/azure-pipelines/microbuild.after.yml
+++ b/azure-pipelines/microbuild.after.yml
@@ -29,7 +29,6 @@ steps:
       usePat: true
     displayName: 📢 Publish to Artifact Services - ProfilingInputs
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-    continueOnError: true
 
   - task: PublishBuildArtifacts@1
     inputs:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.400",
+    "version": "8.0.402",
     "rollForward": "patch",
     "allowPrerelease": false
   },

--- a/tools/MergeFrom-Template.ps1
+++ b/tools/MergeFrom-Template.ps1
@@ -43,7 +43,7 @@ if ($LASTEXITCODE -ne 0) {
 
 $LibTemplateUrl = 'https://github.com/aarnott/Library.Template'
 Spawn-Tool 'git' ('fetch', $LibTemplateUrl, $remoteBranch)
-$SourceCommit = git rev-parse FETCH_HEAD
+$SourceCommit = Spawn-Tool 'git' ('rev-parse', 'FETCH_HEAD')
 $BaseBranch = Spawn-Tool 'git' ('branch', '--show-current')
 $SourceCommitUrl = "$LibTemplateUrl/commit/$SourceCommit"
 


### PR DESCRIPTION
- **Fail OptProf pipeline when profilingInputs can't be published**
- **Add missing OptProf.targets file**
- **Filter VSInsertionMetadata from default.config world**
- **Add comment about multi-targeting projects**
- **Bump .NET SDK to 8.0.402**
- **Fix linux agent on AzDO**
- **Update build agent to macos-14**
- **Notice errors from invocation of `git rev-parse HEAD`**
- **Ignore Rider cache files**
- **Bump dotnet-coverage from 17.12.5 to 17.12.6 (#297)**
- **Do NOT fail a pipeline build due to nuget vulnerabilities**
- **Avoid running tests on mono for test project**
- **Bump nbgv from 3.6.143 to 3.6.146 (#300)**
- **Bump Nerdbank.GitVersioning from 3.6.143 to 3.6.146 (#299)**
- **Bump powershell from 7.4.5 to 7.4.6 (#301)**
- **Touch-up optprof pipelines**
- **Add github workflow to keep current with Library.Template**
