### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "17.14.1",
+      "version": "17.14.2",
       "commands": [
         "dotnet-coverage"
       ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,58 +1,10 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
-	"extends": ["config:recommended"],
-	"semanticCommits": "disabled",
-	"labels": ["dependencies"],
+	"extends": [
+		"github>microsoft/vs-renovate-presets:microbuild",
+		"github>microsoft/vs-renovate-presets:vs_main_dependencies"
+	],
 	"packageRules": [
-		{
-			"matchPackageNames": ["nbgv", "nerdbank.gitversioning"],
-			"groupName": "nbgv and nerdbank.gitversioning updates"
-		},
-		{
-			"matchPackageNames": ["xunit*"],
-			"groupName": "xunit"
-		},
-		{
-			"matchDatasources": ["dotnet-version", "docker"],
-			"matchDepNames": ["dotnet-sdk", "mcr.microsoft.com/dotnet/sdk"],
-			"groupName": "Dockerfile and global.json updates"
-		},
-		{
-			"matchPackageNames": ["*"],
-			"allowedVersions": "!/-g[a-f0-9]+$/"
-		},
-		{
-			"matchPackageNames": [
-				"System.Collections.Immutable",
-				"System.Composition*",
-				"System.Diagnostics.DiagnosticSource",
-				"System.IO.Pipelines",
-				"System.Reflection.Metadata",
-				"System.Text.Json",
-				"System.Threading.Tasks.Dataflow",
-				"Microsoft.Bcl.AsyncInterfaces"
-			],
-			"allowedVersions": "<9.0",
-			"groupName": "Included in .NET runtime"
-		},
-		{
-			"matchPackageNames": ["Microsoft.VisualStudio.Internal.MicroBuild*"],
-			"groupName": "microbuild"
-		},
-		{
-			"matchPackageNames": ["Microsoft.VisualStudio.*"],
-			"groupName": "Visual Studio SDK"
-		},
-		{
-			"matchPackageNames": ["Microsoft.VisualStudio.*"],
-			"matchUpdateTypes": ["patch"],
-			"enabled": false
-		},
-		{
-			"matchPackageNames": ["MessagePack", "MessagePackAnalyzer"],
-			"allowedVersions": "<3.0",
-			"groupName": "MessagePack"
-		},
 		{
 			"matchFileNames": ["Directory.Packages.Analyzers.props"],
 			"enabled": false
@@ -62,8 +14,12 @@
 		{
 			"customType": "regex",
 			"datasourceTemplate": "nuget",
-			"fileMatch": ["test/Microsoft.ServiceHub.Analyzers.Tests/Helpers/ReferencesHelper.cs"],
-			"matchStrings": ["PackageIdentity\\(\"(?<packageName>[^\"]+)\", \"(?<currentValue>[^\"]+)\"\\)"]
+			"fileMatch": [
+				"test/Microsoft.ServiceHub.Analyzers.Tests/Helpers/ReferencesHelper.cs"
+			],
+			"matchStrings": [
+				"PackageIdentity\\(\"(?<packageName>[^\"]+)\", \"(?<currentValue>[^\"]+)\"\\)"
+			]
 		}
 	]
 }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,11 +74,11 @@ jobs:
 
     - name: 💽 Upload artifacts to release
       shell: pwsh
-      if: ${{ github.event.release.assets_url }} != ''
+      if: ${{ github.event_name == 'release' && github.event.release.assets_url != '' }}
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
-        Get-ChildItem '${{ runner.temp }}/deployables' |% {
+        Get-ChildItem '${{ runner.temp }}/deployables' -File -Recurse |% {
           Write-Host "Uploading $($_.Name) to release..."
           gh release -R ${{ github.repository }} upload "${{ github.ref_name }}" $_.FullName
         }

--- a/azure-pipelines/official.yml
+++ b/azure-pipelines/official.yml
@@ -46,7 +46,7 @@ extends:
       codeSignValidation:
         enabled: true
         break: true
-        additionalTargetsGlobPattern: -|Variables-*\*.ps1;-|APIScanInputs-*\**;-|test_symbols-*\**;-|MicroBuild\**
+        additionalTargetsGlobPattern: -|Variables-*\*.ps1;-|LocBin-*\**;-|APIScanInputs-*\**;-|test_symbols-*\**;-|MicroBuild\**
       policheck:
         enabled: true
         exclusionsFile: $(System.DefaultWorkingDirectory)\azure-pipelines\PoliCheckExclusions.xml


### PR DESCRIPTION
- **Do not verify signed binaries in LocBin artifact**
- **Add placeholder option for vs-validation to skip optimization**
- **Update dependency dotnet-coverage to 17.14.2 (#352)**
- **Fix GitHub release workflow in dispatched runs**
- **Drop semanticCommits setting from renovate.json**
- **Switch to renovate rules from Microsoft presets**
