### PR TITLE
Introduce LazyAuthorizationServiceProxy perf optimization

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/Extensions/ServiceManagerReflectionHelpers.cs
+++ b/src/Microsoft.ServiceHub.Framework/Extensions/ServiceManagerReflectionHelpers.cs
@@ -53,7 +53,7 @@ internal static class ServiceManagerReflectionHelpers
 	/// <see cref="AuthorizationServiceClient"/> can be passed directly to the constructor of a ServiceHub service.
 	/// </devremarks>
 	internal static Task<AuthorizationServiceClient> GetAuthorizationServiceClientAsync(IServiceBroker broker, CancellationToken cancellationToken) =>
-		Task.FromResult(new AuthorizationServiceClient(new LazyAuthorizationServiceProxy(broker, JoinableTaskContext.CreateNoOpContext().Factory), ownsAuthorizationService: true));
+		Task.FromResult(new AuthorizationServiceClient(new LazyAuthorizationServiceProxy(broker, joinableTaskFactory: null), ownsAuthorizationService: true));
 
 	/// <summary>
 	/// Helper method for getting a <see cref="AuthorizationServiceClient"/> that always returns "Unauthorized".

--- a/src/Microsoft.ServiceHub.Framework/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.ServiceHub.Framework/PublicAPI.Unshipped.txt
@@ -1,1 +1,8 @@
+Microsoft.ServiceHub.Framework.LazyAuthorizationServiceProxy
+Microsoft.ServiceHub.Framework.LazyAuthorizationServiceProxy.AuthorizationChanged -> System.EventHandler?
+Microsoft.ServiceHub.Framework.LazyAuthorizationServiceProxy.CheckAuthorizationAsync(Microsoft.ServiceHub.Framework.Services.ProtectedOperation! operation, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<bool>
+Microsoft.ServiceHub.Framework.LazyAuthorizationServiceProxy.CredentialsChanged -> System.EventHandler?
+Microsoft.ServiceHub.Framework.LazyAuthorizationServiceProxy.Dispose() -> void
+Microsoft.ServiceHub.Framework.LazyAuthorizationServiceProxy.GetCredentialsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyDictionary<string!, string!>!>
+Microsoft.ServiceHub.Framework.LazyAuthorizationServiceProxy.LazyAuthorizationServiceProxy(Microsoft.ServiceHub.Framework.IServiceBroker! serviceBroker, Microsoft.VisualStudio.Threading.JoinableTaskFactory? joinableTaskFactory) -> void
 static Microsoft.ServiceHub.Framework.ServiceBrokerAggregator.Lazy(System.Func<System.Threading.Tasks.ValueTask<Microsoft.ServiceHub.Framework.IServiceBroker!>>! lazyServiceBroker, Microsoft.VisualStudio.Threading.JoinableTaskFactory? joinableTaskFactory = null) -> Microsoft.ServiceHub.Framework.IServiceBroker!

--- a/src/Microsoft.ServiceHub.Framework/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.ServiceHub.Framework/PublicAPI.Unshipped.txt
@@ -1,8 +1,1 @@
-Microsoft.ServiceHub.Framework.LazyAuthorizationServiceProxy
-Microsoft.ServiceHub.Framework.LazyAuthorizationServiceProxy.AuthorizationChanged -> System.EventHandler?
-Microsoft.ServiceHub.Framework.LazyAuthorizationServiceProxy.CheckAuthorizationAsync(Microsoft.ServiceHub.Framework.Services.ProtectedOperation! operation, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<bool>
-Microsoft.ServiceHub.Framework.LazyAuthorizationServiceProxy.CredentialsChanged -> System.EventHandler?
-Microsoft.ServiceHub.Framework.LazyAuthorizationServiceProxy.Dispose() -> void
-Microsoft.ServiceHub.Framework.LazyAuthorizationServiceProxy.GetCredentialsAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.ValueTask<System.Collections.Generic.IReadOnlyDictionary<string!, string!>!>
-Microsoft.ServiceHub.Framework.LazyAuthorizationServiceProxy.LazyAuthorizationServiceProxy(Microsoft.ServiceHub.Framework.IServiceBroker! serviceBroker, Microsoft.VisualStudio.Threading.JoinableTaskFactory? joinableTaskFactory) -> void
 static Microsoft.ServiceHub.Framework.ServiceBrokerAggregator.Lazy(System.Func<System.Threading.Tasks.ValueTask<Microsoft.ServiceHub.Framework.IServiceBroker!>>! lazyServiceBroker, Microsoft.VisualStudio.Threading.JoinableTaskFactory? joinableTaskFactory = null) -> Microsoft.ServiceHub.Framework.IServiceBroker!

--- a/src/Microsoft.ServiceHub.Framework/ServiceHub/LazyAuthorizationServiceProxy.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServiceHub/LazyAuthorizationServiceProxy.cs
@@ -1,0 +1,95 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.ServiceHub.Framework.Services;
+using Microsoft.VisualStudio.Threading;
+
+namespace Microsoft.ServiceHub.Framework;
+
+/// <summary>
+/// An authorization service that waits until it is used before it is created. This is useful because most ServiceHub services do not use their AuthorizationService and so resources are wasted acquiring one.
+/// </summary>
+public class LazyAuthorizationServiceProxy : IAuthorizationService, IDisposable
+{
+	private readonly CancellationTokenSource disposalToken = new();
+	private readonly AsyncLazy<IAuthorizationService> authorizationService;
+
+	private bool disposed;
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="LazyAuthorizationServiceProxy"/> class.
+	/// </summary>
+	/// <param name="serviceBroker">A service broker used to acquire the activation service.</param>
+	/// <param name="joinableTaskFactory">An optional <see cref="JoinableTaskFactory"/> to use when scheduling async work, to avoid deadlocks in an application with a main thread.</param>
+	public LazyAuthorizationServiceProxy(IServiceBroker serviceBroker, JoinableTaskFactory? joinableTaskFactory)
+	{
+		Requires.NotNull(serviceBroker);
+		this.authorizationService = new(() => this.ActivateAsync(serviceBroker), joinableTaskFactory ?? JoinableTaskContext.CreateNoOpContext().Factory);
+	}
+
+	/// <inheritdoc/>
+	public event EventHandler? CredentialsChanged;
+
+	/// <inheritdoc/>
+	public event EventHandler? AuthorizationChanged;
+
+	private CancellationToken DisposeToken => this.disposalToken.Token;
+
+	/// <inheritdoc/>
+	public async ValueTask<bool> CheckAuthorizationAsync(ProtectedOperation operation, CancellationToken cancellationToken = default)
+	{
+		IAuthorizationService service = await this.authorizationService.GetValueAsync(cancellationToken).ConfigureAwait(false);
+		return await service.CheckAuthorizationAsync(operation, cancellationToken).ConfigureAwait(false);
+	}
+
+	/// <inheritdoc/>
+	public void Dispose()
+	{
+		if (!this.disposed)
+		{
+			this.disposed = true;
+			this.disposalToken.Cancel();
+
+			// If this value hasn't been created yet, the `DisposeToken` will throw right away because it was cancelled
+			// and a default authorization service will be returned without going through the service broker to request the actual service proxy.
+			IAuthorizationService service = this.authorizationService.GetValue();
+
+			service.CredentialsChanged -= this.AuthService_CredentialsChanged;
+			service.AuthorizationChanged -= this.AuthService_AuthorizationChanged;
+
+			(service as IDisposable)?.Dispose();
+			this.disposalToken.Dispose();
+		}
+	}
+
+	/// <inheritdoc/>
+	public async ValueTask<IReadOnlyDictionary<string, string>> GetCredentialsAsync(CancellationToken cancellationToken = default)
+	{
+		IAuthorizationService service = await this.authorizationService.GetValueAsync(cancellationToken).ConfigureAwait(false);
+		return await service.GetCredentialsAsync(cancellationToken).ConfigureAwait(false);
+	}
+
+	private async Task<IAuthorizationService> ActivateAsync(IServiceBroker serviceBroker)
+	{
+		IAuthorizationService? authService = null;
+
+		try
+		{
+			this.DisposeToken.ThrowIfCancellationRequested();
+			authService = await serviceBroker.GetProxyAsync<IAuthorizationService>(FrameworkServices.Authorization, this.DisposeToken).ConfigureAwait(false);
+		}
+		catch (Exception e) when (e is ServiceActivationFailedException || e is OperationCanceledException || e is TaskCanceledException)
+		{
+		}
+
+		authService ??= new DefaultAuthorizationService();
+		authService.CredentialsChanged += this.AuthService_CredentialsChanged;
+		authService.AuthorizationChanged += this.AuthService_AuthorizationChanged;
+
+		return authService;
+	}
+
+	private void AuthService_AuthorizationChanged(object? sender, EventArgs e) => this.AuthorizationChanged?.Invoke(sender, e);
+
+	private void AuthService_CredentialsChanged(object? sender, EventArgs e) => this.CredentialsChanged?.Invoke(sender, e);
+}

--- a/src/Microsoft.ServiceHub.Framework/ServiceHub/LazyAuthorizationServiceProxy.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServiceHub/LazyAuthorizationServiceProxy.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ServiceHub.Framework;
 /// <summary>
 /// An authorization service that waits until it is used before it is created. This is useful because most ServiceHub services do not use their AuthorizationService and so resources are wasted acquiring one.
 /// </summary>
-public class LazyAuthorizationServiceProxy : IAuthorizationService, IDisposable
+internal class LazyAuthorizationServiceProxy : IAuthorizationService, IDisposable
 {
 	private readonly CancellationTokenSource disposalToken = new();
 	private readonly AsyncLazy<IAuthorizationService> authorizationService;

--- a/src/Microsoft.ServiceHub.Framework/ServiceHub/LazyAuthorizationServiceProxy.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServiceHub/LazyAuthorizationServiceProxy.cs
@@ -60,16 +60,8 @@ public class LazyAuthorizationServiceProxy : IAuthorizationService, IDisposable
 
 	private async Task<IAuthorizationService> ActivateAsync(IServiceBroker serviceBroker)
 	{
-		IAuthorizationService? authService = null;
-
-		try
-		{
-			this.DisposeToken.ThrowIfCancellationRequested();
-			authService = await serviceBroker.GetProxyAsync<IAuthorizationService>(FrameworkServices.Authorization, this.DisposeToken).ConfigureAwait(false);
-		}
-		catch (Exception e) when (e is ServiceActivationFailedException)
-		{
-		}
+		this.DisposeToken.ThrowIfCancellationRequested();
+		IAuthorizationService? authService = await serviceBroker.GetProxyAsync<IAuthorizationService>(FrameworkServices.Authorization, this.DisposeToken).ConfigureAwait(false);
 
 		authService ??= new DefaultAuthorizationService();
 		authService.CredentialsChanged += this.AuthService_CredentialsChanged;

--- a/test/Microsoft.ServiceHub.Framework.Tests/LazyAuthorizationServiceProxyTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/LazyAuthorizationServiceProxyTests.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.IO.Pipelines;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.ServiceHub.Framework.Services;
+
+public class LazyAuthorizationServiceProxyTests : TestBase
+{
+	public LazyAuthorizationServiceProxyTests(ITestOutputHelper logger)
+		: base(logger)
+	{
+	}
+
+	[Fact]
+	public async Task ActivatedAuthorizationServiceProxyIsDisposed()
+	{
+		ServiceBroker.AuthorizationService authorizationService = new();
+		ServiceBroker broker = new(authorizationService);
+		LazyAuthorizationServiceProxy proxy = new(broker, joinableTaskFactory: null);
+
+		Assert.True(await proxy.CheckAuthorizationAsync(new ProtectedOperation("operation"), this.TimeoutToken));
+
+		proxy.Dispose();
+		Assert.True(authorizationService.Disposed);
+	}
+
+	[Fact]
+	public async Task CanActivateAndUseAuthorizationService()
+	{
+		ServiceBroker.AuthorizationService authorizationService = new();
+		ServiceBroker broker = new(authorizationService);
+		using LazyAuthorizationServiceProxy proxy = new(broker, joinableTaskFactory: null);
+
+		Assert.True(await proxy.CheckAuthorizationAsync(new ProtectedOperation("operation"), this.TimeoutToken));
+		Assert.NotNull(await proxy.GetCredentialsAsync(this.TimeoutToken));
+	}
+
+	[Fact]
+	public void DisposingServiceBeforeActivationDoesNotRequestProxy()
+	{
+		AlwaysThrowingServiceBroker broker = new();
+		LazyAuthorizationServiceProxy proxy = new(broker, joinableTaskFactory: null);
+		proxy.Dispose();
+
+		Assert.Equal(0, broker.GetProxyAsyncCalls);
+	}
+
+	private class AlwaysThrowingServiceBroker : IServiceBroker
+	{
+		private int getProxyAsyncCalls;
+
+		public event EventHandler<BrokeredServicesChangedEventArgs>? AvailabilityChanged
+		{
+			add => throw new NotImplementedException();
+			remove => throw new NotImplementedException();
+		}
+
+		public int GetProxyAsyncCalls => this.getProxyAsyncCalls;
+
+		public ValueTask<IDuplexPipe?> GetPipeAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions options = default, CancellationToken cancellationToken = default) =>
+			throw new NotImplementedException();
+
+		public ValueTask<T?> GetProxyAsync<T>(ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options = default, CancellationToken cancellationToken = default)
+			where T : class
+		{
+			this.getProxyAsyncCalls++;
+			throw new NotImplementedException();
+		}
+	}
+
+	private class ServiceBroker : IServiceBroker
+	{
+		private readonly AuthorizationService authorizationService;
+
+		public ServiceBroker(AuthorizationService authorizationService)
+		{
+			this.authorizationService = authorizationService;
+		}
+
+		public event EventHandler<BrokeredServicesChangedEventArgs>? AvailabilityChanged
+		{
+			add { }
+			remove { }
+		}
+
+		public ValueTask<IDuplexPipe?> GetPipeAsync(ServiceMoniker serviceMoniker, ServiceActivationOptions options = default, CancellationToken cancellationToken = default) =>
+			throw new NotImplementedException();
+
+		public ValueTask<T?> GetProxyAsync<T>(ServiceRpcDescriptor serviceDescriptor, ServiceActivationOptions options = default, CancellationToken cancellationToken = default)
+			where T : class
+		{
+			if (serviceDescriptor.Moniker.Equals(FrameworkServices.Authorization.Moniker))
+			{
+				return new ValueTask<T?>((T?)(this.authorizationService as object));
+			}
+
+			throw new NotSupportedException();
+		}
+
+		public class AuthorizationService : IAuthorizationService, IDisposable
+		{
+			private bool disposed;
+
+			public event EventHandler? CredentialsChanged
+			{
+				add { }
+				remove { }
+			}
+
+			public event EventHandler? AuthorizationChanged
+			{
+				add { }
+				remove { }
+			}
+
+			public bool Disposed => this.disposed;
+
+			public ValueTask<bool> CheckAuthorizationAsync(ProtectedOperation operation, CancellationToken cancellationToken = default) =>
+				new(true);
+
+			public void Dispose() => this.disposed = true;
+
+			public ValueTask<IReadOnlyDictionary<string, string>> GetCredentialsAsync(CancellationToken cancellationToken = default) =>
+				new(new Dictionary<string, string>());
+		}
+	}
+}

--- a/test/Microsoft.ServiceHub.Framework.Tests/Microsoft.ServiceHub.Framework.Tests.csproj
+++ b/test/Microsoft.ServiceHub.Framework.Tests/Microsoft.ServiceHub.Framework.Tests.csproj
@@ -29,4 +29,9 @@
     <PackageReference Include="xunit.v3" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\..\src\Microsoft.ServiceHub.Framework\ServiceHub\LazyAuthorizationServiceProxy.cs" />
+    <Compile Include="..\..\src\Microsoft.ServiceHub.Framework\Services\DefaultAuthorizationService.cs" />
+  </ItemGroup>
+  
 </Project>


### PR DESCRIPTION
Most ServiceHub services don't use the authorization service that we provide them in their service factory `CreateAsync`. To optimize the more common case, this change allows us to not activate the authorization service unless the service actually uses it.