### PR TITLE
Allow null broker in lazy authorization service client

### DIFF
--- a/test/Microsoft.ServiceHub.Framework.Tests/LazyAuthorizationServiceProxyTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/LazyAuthorizationServiceProxyTests.cs
@@ -13,6 +13,13 @@ public class LazyAuthorizationServiceProxyTests : TestBase
 	}
 
 	[Fact]
+	public async Task CanActivateWithNullBroker()
+	{
+		using LazyAuthorizationServiceProxy proxy = new(serviceBroker: null, joinableTaskFactory: null);
+		Assert.False(await proxy.CheckAuthorizationAsync(new ProtectedOperation("operation"), this.TimeoutToken));
+	}
+
+	[Fact]
 	public async Task ActivatedAuthorizationServiceProxyIsDisposed()
 	{
 		ServiceBroker.AuthorizationService authorizationService = new();


### PR DESCRIPTION
StorageExplorer does not have an in-proc ServiceBroker to acquire an authorization service. Requiring a service broker is a VS thing, but all ServiceHub consumers don't necessarily need to have one