### PR TITLE
Fix serializability of RPC calls to `IAuthorizationService`

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/FrameworkServices.cs
+++ b/src/Microsoft.ServiceHub.Framework/FrameworkServices.cs
@@ -117,6 +117,8 @@ public static partial class FrameworkServices
 	[JsonSerializable(typeof(ServiceActivationOptions))]
 	[JsonSerializable(typeof(ServiceBrokerClientMetadata))]
 	[JsonSerializable(typeof(BrokeredServicesChangedEventArgs))]
+	[JsonSerializable(typeof(ProtectedOperation))]
 	[JsonSerializable(typeof(Guid))]
+	[JsonSerializable(typeof(EventArgs))]
 	private partial class SourceGenerationContext : JsonSerializerContext;
 }

--- a/test/Microsoft.ServiceHub.Framework.Tests/AuthorizationServiceTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/AuthorizationServiceTests.cs
@@ -1,0 +1,52 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.ServiceHub.Framework;
+using Microsoft.ServiceHub.Framework.Services;
+using Microsoft.VisualStudio.Threading;
+
+public class AuthorizationServiceTests : RpcTestBase<IAuthorizationService, AuthorizationServiceMock>
+{
+	public AuthorizationServiceTests(ITestOutputHelper logger)
+		: base(logger, FrameworkServices.Authorization)
+	{
+	}
+
+	[Fact]
+	public async Task AuthorizeOrThrowAsync()
+	{
+		ProtectedOperation expected = new ProtectedOperation("moniker", 5);
+		await this.ClientProxy.AuthorizeOrThrowAsync(expected, this.TimeoutToken);
+		Assert.Equal(expected, this.Service.LastReceivedOperation);
+	}
+
+	[Fact]
+	public async Task GetCredentialsAsync()
+	{
+		this.Service.CredentialsToReturn = new Dictionary<string, string>
+		{
+			["token"] = "abc",
+		};
+
+		IReadOnlyDictionary<string, string> actual = await this.ClientProxy.GetCredentialsAsync(this.TimeoutToken);
+		Assert.Equal("abc", actual["token"]);
+	}
+
+	[Fact]
+	public async Task AuthorizationChanged()
+	{
+		AsyncManualResetEvent authorizationChangedEvent = new();
+		this.ClientProxy.AuthorizationChanged += (s, e) => authorizationChangedEvent.Set();
+		this.Service.OnAuthorizationChanged();
+		await authorizationChangedEvent.WaitAsync(this.TimeoutToken);
+	}
+
+	[Fact]
+	public async Task CredentialsChanged()
+	{
+		AsyncManualResetEvent credentialsChangedEvent = new();
+		this.ClientProxy.CredentialsChanged += (s, e) => credentialsChangedEvent.Set();
+		this.Service.OnCredentialsChanged();
+		await credentialsChangedEvent.WaitAsync(this.TimeoutToken);
+	}
+}

--- a/test/Microsoft.ServiceHub.Framework.Tests/Mocks/AuthorizationServiceMock.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/Mocks/AuthorizationServiceMock.cs
@@ -1,0 +1,30 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.ServiceHub.Framework.Services;
+
+public class AuthorizationServiceMock : IAuthorizationService
+{
+	public event EventHandler? CredentialsChanged;
+
+	public event EventHandler? AuthorizationChanged;
+
+	internal ProtectedOperation? LastReceivedOperation { get; set; }
+
+	internal IReadOnlyDictionary<string, string>? CredentialsToReturn { get; set; }
+
+	public ValueTask<bool> CheckAuthorizationAsync(ProtectedOperation operation, CancellationToken cancellationToken = default)
+	{
+		this.LastReceivedOperation = operation;
+		return new(true);
+	}
+
+	public ValueTask<IReadOnlyDictionary<string, string>> GetCredentialsAsync(CancellationToken cancellationToken = default)
+	{
+		return new(this.CredentialsToReturn ?? new Dictionary<string, string>());
+	}
+
+	public virtual void OnCredentialsChanged() => this.CredentialsChanged?.Invoke(this, EventArgs.Empty);
+
+	public virtual void OnAuthorizationChanged() => this.AuthorizationChanged?.Invoke(this, EventArgs.Empty);
+}


### PR DESCRIPTION
This regressed in #376 because in that change we require that all `FrameworkServices` descriptors be fully AOT compatible and thus every serialized type must be attributed for System.Text.Json's serialization. But we were missing a couple types. 


TDD: We were missing tests too, so I added the tests, which failed, then added the attributes, which got them to pass.

Fixes devdiv-2634381