### PR TITLE
Add `DisplayName` property to descriptors

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.228" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.13.16" />
     <PackageVersion Include="NuGet.Protocol" Version="6.13.2" />
-    <PackageVersion Include="StreamJsonRpc" Version="2.24.76" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.25.6" />
     <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageVersion Include="System.Text.Json" Version="8.0.6" />

--- a/src/Microsoft.ServiceHub.Framework/ServiceJsonRpcDescriptor.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServiceJsonRpcDescriptor.cs
@@ -37,6 +37,7 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 	{
 		this.Formatter = formatter;
 		this.MessageDelimiter = messageDelimiter;
+		this.DisplayName = this.DefaultDisplayName;
 	}
 
 	/// <summary>
@@ -54,6 +55,7 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 		this.Formatter = formatter;
 		this.MessageDelimiter = messageDelimiter;
 		this.MultiplexingStreamOptions = multiplexingStreamOptions?.GetFrozenCopy();
+		this.DisplayName = this.DefaultDisplayName;
 	}
 
 	/// <summary>
@@ -68,6 +70,7 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 		this.MultiplexingStreamOptions = copyFrom.MultiplexingStreamOptions;
 		this.ExceptionStrategy = copyFrom.ExceptionStrategy;
 		this.AdditionalServiceInterfaces = copyFrom.AdditionalServiceInterfaces;
+		this.DisplayName = copyFrom.DisplayName;
 	}
 
 	/// <summary>
@@ -154,11 +157,22 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 	public ImmutableArray<Type>? AdditionalServiceInterfaces { get; private set; }
 
 	/// <summary>
+	/// Gets the display name to use for the <see cref="JsonRpc"/> instance.
+	/// </summary>
+	/// <value>The default value is the full name of this descriptor's type.</value>
+	public string DisplayName { get; private set; }
+
+	/// <summary>
+	/// Gets the default display name based on this descriptor's type.
+	/// </summary>
+	private protected string DefaultDisplayName => this.GetType().FullName!;
+
+	/// <summary>
 	/// Gets a string for the debugger to display for this struct.
 	/// </summary>
 	[ExcludeFromCodeCoverage]
 	[DebuggerBrowsable(DebuggerBrowsableState.Never)]
-	private protected string DebuggerDisplay => $"{this.Moniker.Name} via {this.Protocol}/{this.MessageDelimiter}/{this.Formatter}";
+	private protected string DebuggerDisplay => $"{this.Moniker.Name} via {this.Protocol}/{this.MessageDelimiter}/{this.Formatter} ({this.DisplayName})";
 
 	/// <summary>
 	/// Wraps some target object with a proxy that gives the caller the similar semantics to calling
@@ -275,6 +289,25 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 
 		var result = (ServiceJsonRpcDescriptor)this.Clone();
 		result.AdditionalServiceInterfaces = value;
+		return result;
+	}
+
+	/// <summary>
+	/// Returns an instance of <see cref="ServiceJsonRpcDescriptor"/> that resembles this one,
+	/// but with the <see cref="DisplayName" /> property set to a new value.
+	/// </summary>
+	/// <param name="displayName">The new value for the <see cref="DisplayName"/> property.</param>
+	/// <returns>A clone of this instance, with the property changed. Or this same instance if the property already matches.</returns>
+	public ServiceJsonRpcDescriptor WithDisplayName(string displayName)
+	{
+		Requires.NotNullOrEmpty(displayName, nameof(displayName));
+		if (this.DisplayName == displayName)
+		{
+			return this;
+		}
+
+		var result = (ServiceJsonRpcDescriptor)this.Clone();
+		result.DisplayName = displayName;
 		return result;
 	}
 
@@ -405,7 +438,10 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 	{
 		Requires.NotNull(handler, nameof(handler));
 
-		return new JsonRpc(handler);
+		return new JsonRpc(handler)
+		{
+			DisplayName = this.DisplayName,
+		};
 	}
 
 	/// <summary>

--- a/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcDescriptor_ProxyTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcDescriptor_ProxyTests.cs
@@ -237,6 +237,8 @@ public class ServiceJsonRpcDescriptor_ProxyTests : ServiceRpcDescriptor_ProxyTes
 	protected override ServiceRpcDescriptor DescriptorWithExceptionStrategy(ServiceRpcDescriptor descriptor, ExceptionProcessing strategy)
 		=> ((ServiceJsonRpcDescriptor)descriptor).WithExceptionStrategy(strategy);
 
+	protected override string GetDisplayName(ServiceRpcDescriptor descriptor) => throw new NotSupportedException();
+
 	private protected class SomeService : SomeNonDisposableService, IServerWithVoidMethod
 	{
 		public void NoReturnValue() => this.NoReturnValue_Invoked = true;

--- a/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcDescriptor_RpcProxyTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcDescriptor_RpcProxyTests.cs
@@ -38,4 +38,6 @@ public class ServiceJsonRpcDescriptor_RpcProxyTests : ServiceRpcDescriptor_Proxy
 
 	protected override ServiceRpcDescriptor DescriptorWithExceptionStrategy(ServiceRpcDescriptor descriptor, ExceptionProcessing strategy)
 		=> ((ServiceJsonRpcDescriptor)descriptor).WithExceptionStrategy(strategy);
+
+	protected override string GetDisplayName(ServiceRpcDescriptor descriptor) => ((ServiceJsonRpcDescriptor)descriptor).DisplayName;
 }

--- a/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcPolyTypeDescriptorTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcPolyTypeDescriptorTests.cs
@@ -1,0 +1,33 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using System.Diagnostics;
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Threading;
+using PolyType;
+
+public partial class ServiceJsonRpcPolyTypeDescriptorTests
+{
+	private static readonly ServiceMoniker SomeMoniker = new ServiceMoniker("Some name");
+	private static readonly ServiceMoniker SomeOtherMoniker = new ServiceMoniker("Some other name");
+	private static readonly TraceSource SomeTraceSource = new("test");
+	private static readonly JoinableTaskFactory SomeJoinableTaskFactory = new JoinableTaskContext().Factory;
+
+	[Fact]
+	public void WithDisplayName()
+	{
+		ServiceJsonRpcPolyTypeDescriptor d = new(SomeMoniker, ServiceJsonRpcPolyTypeDescriptor.Formatters.NerdbankMessagePack, ServiceJsonRpcPolyTypeDescriptor.MessageDelimiters.BigEndianInt32LengthHeader, Witness.GeneratedTypeShapeProvider);
+		Assert.Contains(d.GetType().FullName!, d.DisplayName);
+		Assert.Contains(Witness.GeneratedTypeShapeProvider.GetType().FullName!, d.DisplayName);
+		TestContext.Current.TestOutputHelper?.WriteLine(d.DisplayName);
+		ServiceJsonRpcPolyTypeDescriptor d2 = d.WithExceptionStrategy(StreamJsonRpc.ExceptionProcessing.CommonErrorData);
+		Assert.Equal(d.DisplayName, d2.DisplayName);
+		ServiceJsonRpcPolyTypeDescriptor d3 = d.WithDisplayName("Custom name");
+		Assert.Equal("Custom name", d3.DisplayName);
+		ServiceJsonRpcPolyTypeDescriptor d4 = d3.WithExceptionStrategy(StreamJsonRpc.ExceptionProcessing.ISerializable);
+		Assert.Equal("Custom name", d4.DisplayName);
+	}
+
+	[GenerateShapeFor<bool>]
+	private partial class Witness;
+}

--- a/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcPolyTypeDescriptor_ProxyTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcPolyTypeDescriptor_ProxyTests.cs
@@ -25,4 +25,6 @@ public class ServiceJsonRpcPolyTypeDescriptor_ProxyTests : ServiceRpcDescriptor_
 
 	protected override ServiceRpcDescriptor DescriptorWithExceptionStrategy(ServiceRpcDescriptor descriptor, ExceptionProcessing strategy)
 		=> ((ServiceJsonRpcPolyTypeDescriptor)descriptor).WithExceptionStrategy(strategy);
+
+	protected override string GetDisplayName(ServiceRpcDescriptor descriptor) => throw new NotSupportedException();
 }

--- a/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcPolyTypeDescriptor_RpcProxyTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcPolyTypeDescriptor_RpcProxyTests.cs
@@ -60,4 +60,6 @@ public class ServiceJsonRpcPolyTypeDescriptor_RpcProxyTests : ServiceRpcDescript
 
 	protected override ServiceRpcDescriptor DescriptorWithExceptionStrategy(ServiceRpcDescriptor descriptor, ExceptionProcessing strategy)
 		=> ((ServiceJsonRpcPolyTypeDescriptor)descriptor).WithExceptionStrategy(strategy);
+
+	protected override string GetDisplayName(ServiceRpcDescriptor descriptor) => ((ServiceJsonRpcPolyTypeDescriptor)descriptor).DisplayName;
 }

--- a/test/Microsoft.ServiceHub.Framework.Tests/ServiceRpcDescriptorTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/ServiceRpcDescriptorTests.cs
@@ -6,7 +6,6 @@ using System.IO.Pipelines;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Threading;
 using Nerdbank.Streams;
-using Xunit;
 
 public class ServiceRpcDescriptorTests
 {
@@ -94,6 +93,19 @@ public class ServiceRpcDescriptorTests
 		MockServiceRpcDescriptor copy = (MockServiceRpcDescriptor)descriptor.WithJoinableTaskFactory(SomeJoinableTaskFactory);
 		Assert.Same(SomeJoinableTaskFactory, copy.JoinableTaskFactory);
 		Assert.Null(descriptor.JoinableTaskFactory);
+	}
+
+	[Fact]
+	public void WithDisplayName()
+	{
+		ServiceJsonRpcDescriptor d = new(SomeMoniker, ServiceJsonRpcDescriptor.Formatters.UTF8, ServiceJsonRpcDescriptor.MessageDelimiters.HttpLikeHeaders);
+		Assert.Equal(d.GetType().FullName, d.DisplayName);
+		ServiceJsonRpcDescriptor d2 = d.WithExceptionStrategy(StreamJsonRpc.ExceptionProcessing.CommonErrorData);
+		Assert.Equal(d.DisplayName, d2.DisplayName);
+		ServiceJsonRpcDescriptor d3 = d.WithDisplayName("Custom name");
+		Assert.Equal("Custom name", d3.DisplayName);
+		ServiceJsonRpcDescriptor d4 = d3.WithExceptionStrategy(StreamJsonRpc.ExceptionProcessing.ISerializable);
+		Assert.Equal("Custom name", d4.DisplayName);
 	}
 
 	[Fact]

--- a/test/Microsoft.ServiceHub.Framework.Tests/ServiceRpcDescriptor_ProxyTestBase.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/ServiceRpcDescriptor_ProxyTestBase.cs
@@ -343,6 +343,20 @@ public abstract partial class ServiceRpcDescriptor_ProxyTestBase : TestBase
 		ISomeServiceDisposable proxy = this.CreateProxy<ISomeServiceDisposable>(service, this.DescriptorWithAdditionalServiceInterfaces(this.SomeDescriptor, [typeof(ISomeService)]));
 	}
 
+	[Fact]
+	public void DisplayNameAppliedToJsonRpc()
+	{
+		ISomeService proxy = this.CreateProxy<ISomeService>(new SomeNonDisposableService());
+		if (proxy is IJsonRpcClientProxy { JsonRpc: { } jsonRpc })
+		{
+			Assert.Equal(this.GetDisplayName(this.SomeDescriptor), jsonRpc.DisplayName);
+		}
+		else
+		{
+			Assert.Skip("Proxy doesn't implement IJsonRpcClientProxy, so it doesn't have a JsonRpc property to check.");
+		}
+	}
+
 	[return: NotNullIfNotNull("target")]
 	protected abstract T? CreateProxy<T>(T? target, ServiceRpcDescriptor descriptor)
 		where T : class;
@@ -354,6 +368,8 @@ public abstract partial class ServiceRpcDescriptor_ProxyTestBase : TestBase
 	protected abstract ServiceRpcDescriptor DescriptorWithAdditionalServiceInterfaces(ServiceRpcDescriptor descriptor, ImmutableArray<Type>? additionalServiceInterfaces);
 
 	protected abstract ServiceRpcDescriptor DescriptorWithExceptionStrategy(ServiceRpcDescriptor descriptor, ExceptionProcessing strategy);
+
+	protected abstract string GetDisplayName(ServiceRpcDescriptor descriptor);
 
 	private protected class SomeNonDisposableService : ISomeService, ISomeService2, ISomeService.IPublicInterfaceUnderInternalOne
 	{


### PR DESCRIPTION
These pass to the `JsonRpc` objects they create (where applicable) to assist with backtracing a `JsonRpc` object back to the descriptor that