### PR TITLE
Fix servicebroker-npm uuid v13 fallout and restore pin regressions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <CodeAnalysisVersion>5.0.0</CodeAnalysisVersion>
     <CodefixTestingVersion>1.1.2</CodefixTestingVersion>
     <MicrosoftCodeAnalysisAnalyzersVersion>4.14.0</MicrosoftCodeAnalysisAnalyzersVersion>
-    <VSThreadingVersion>18.0.47</VSThreadingVersion>
+    <VSThreadingVersion>18.0.57</VSThreadingVersion>
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="Microsoft.IO.Redist" Version="6.1.0" />
@@ -33,7 +33,7 @@
     <PackageVersion Include="Microsoft.Windows.CsWin32" Version="0.3.269" />
     <PackageVersion Include="Nerdbank.Streams" Version="2.13.16" />
     <PackageVersion Include="NuGet.Protocol" Version="7.3.0" />
-    <PackageVersion Include="StreamJsonRpc" Version="2.25.6" />
+    <PackageVersion Include="StreamJsonRpc" Version="2.25.8" />
     <PackageVersion Include="System.Collections.Immutable" Version="10.0.2" />
     <PackageVersion Include="System.CommandLine" Version="2.0.2" />
     <PackageVersion Include="System.Text.Json" Version="10.0.2" />

--- a/src/servicebroker-npm/package.json
+++ b/src/servicebroker-npm/package.json
@@ -33,7 +33,6 @@
 		"nerdbank-streams": "^2.13.16",
 		"strict-event-emitter-types": "^2.0.0",
 		"string-hash": "^1.1.3",
-		"uuid": "^13.0.0",
 		"vscode-jsonrpc": "^8.1.0"
 	},
 	"devDependencies": {

--- a/src/servicebroker-npm/src/IpcRelayServiceBroker.ts
+++ b/src/servicebroker-npm/src/IpcRelayServiceBroker.ts
@@ -8,7 +8,7 @@ import { ServiceMoniker } from './ServiceMoniker'
 import { IDisposable } from './IDisposable'
 import { IRemoteServiceBroker } from './IRemoteServiceBroker'
 import { ServiceBrokerEmitter, IServiceBroker } from './IServiceBroker'
-import { v4 as uuid } from 'uuid'
+import { randomUUID } from 'crypto'
 import { createServer, Server } from 'net'
 import { BrokeredServicesChangedArgs } from './BrokeredServicesChangedArgs'
 import { RpcEventServer } from './ServiceRpcDescriptor'
@@ -48,8 +48,8 @@ export class IpcRelayServiceBroker extends (EventEmitter as new () => ServiceBro
 			return {}
 		}
 
-		const requestId = uuid()
-		const pipeName = path.join(PIPE_NAME_PREFIX, uuid())
+		const requestId = randomUUID()
+		const pipeName = path.join(PIPE_NAME_PREFIX, randomUUID())
 
 		const server = createServer(serverPipe => {
 			// Drop the entry from our map once the connection has been made.

--- a/src/servicebroker-npm/src/MultiplexingRelayServiceBroker.ts
+++ b/src/servicebroker-npm/src/MultiplexingRelayServiceBroker.ts
@@ -12,7 +12,7 @@ import { ServiceBrokerClientMetadata } from './ServiceBrokerClientMetadata'
 import { ServiceMoniker } from './ServiceMoniker'
 import { FrameworkServices } from './FrameworkServices'
 import caught from 'caught'
-import { v4 as uuid } from 'uuid'
+import { randomUUID } from 'crypto'
 import { RpcEventServer } from './ServiceRpcDescriptor'
 
 export class MultiplexingRelayServiceBroker
@@ -75,7 +75,7 @@ export class MultiplexingRelayServiceBroker
 		options?: ServiceActivationOptions | undefined,
 		cancellationToken?: CancellationToken | undefined
 	): Promise<RemoteServiceConnectionInfo> {
-		const requestId = uuid()
+		const requestId = randomUUID()
 		options = options ? { ...options } : {}
 		options.multiplexingStream = this.multiplexingStreamWithClient
 		const servicePipe = await this.serviceBroker.getPipe(serviceMoniker, options, cancellationToken)

--- a/src/servicebroker-npm/test/testAssets/testRemoteServiceBroker.ts
+++ b/src/servicebroker-npm/test/testAssets/testRemoteServiceBroker.ts
@@ -8,7 +8,7 @@ import { ServiceBrokerClientMetadata } from '../../src/ServiceBrokerClientMetada
 import { ServiceMoniker } from '../../src/ServiceMoniker'
 import { ServiceBrokerEmitter } from '../../src/IServiceBroker'
 import { PIPE_NAME_PREFIX } from '../../src/constants'
-import { v4 as uuid } from 'uuid'
+import { randomUUID } from 'crypto'
 import { createServer, Server } from 'net'
 import path from 'path'
 
@@ -24,7 +24,7 @@ export class TestRemoteServiceBroker extends (EventEmitter as new () => ServiceB
 	constructor() {
 		super()
 
-		this.testPipeName = path.join(PIPE_NAME_PREFIX, 'testRemoteServiceBroker' + uuid())
+		this.testPipeName = path.join(PIPE_NAME_PREFIX, 'testRemoteServiceBroker' + randomUUID())
 
 		this.server = createServer()
 		this.server.listen(this.testPipeName)

--- a/src/servicebroker-npm/yarn.lock
+++ b/src/servicebroker-npm/yarn.lock
@@ -1188,7 +1188,6 @@ __metadata:
     ts-node: "npm:10.9.2"
     typescript: "npm:5.9.3"
     typescript-eslint: "npm:8.56.0"
-    uuid: "npm:^13.0.0"
     vscode-jsonrpc: "npm:^8.1.0"
     yargs: "npm:18.0.0"
   languageName: unknown
@@ -6212,15 +6211,6 @@ __metadata:
   dependencies:
     punycode: "npm:^2.1.0"
   checksum: 10/b271ca7e3d46b7160222e3afa3e531505161c9a4e097febae9664e4b59912f4cbe94861361a4175edac3a03fee99d91e44b6a58c17a634bc5a664b19fc76fbcb
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^13.0.0":
-  version: 13.0.0
-  resolution: "uuid@npm:13.0.0"
-  bin:
-    uuid: ./dist-node/bin/uuid
-  checksum: 10/2742b24d1e00257e60612572e4d28679423469998cafbaf1fe9f1482e3edf9c40754b31bfdb3d08d71b29239f227a304588f75210b3b48f2609f0673f1feccef
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
This branch fixes two regressions that were blocking unrelated PRs:

- Fix `servicebroker-npm` tests and packaging after the upstream `uuid` v13 update switched the package to an ESM-only entrypoint.
- Fix restore failures caused by stale central package pins for `StreamJsonRpc` and `Microsoft.VisualStudio.Threading.Analyzers`.

## What changed
- Replaced direct `uuid` package usage in `servicebroker-npm` with Node's built-in `crypto.randomUUID()`.
- Removed the now-unused `uuid` dependency from the npm package manifest and lockfile.
- Updated central package management in `Directory.Packages.props` to align with current transitive minimums:
  - `StreamJsonRpc` to `2.25.8`
  - `Microsoft.VisualStudio.Threading*` to `18.0.57`

## Why
The original break was not caused by PR #449. After the upstream `uuid` dependency update, the current Jest setup tried to load an ESM-only package and failed. Separately, Azure restore was failing during `init.ps1` because the branch still had older centrally managed package versions than the current transitive dependency graph requires.

Together, these fixes restore the affected JavaScript test path and the Azure restore path that were causing multiple PRs to fail.

## Validation
- `dotnet restore`
- `node .yarn/releases/yarn-4.12.0.cjs test` in `src/servicebroker-npm`
- `pwsh ./src/servicebroker-npm/pack.ps1`
- `dotnet docfx docfx/docfx.json --warningsAsErrors --disableGitFeatures`