### PR TITLE
Several dependency updates

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -10,7 +10,7 @@
       "rollForward": false
     },
     "dotnet-coverage": {
-      "version": "18.6.2",
+      "version": "18.7.0",
       "commands": [
         "dotnet-coverage"
       ],

--- a/src/servicebroker-npm/package.json
+++ b/src/servicebroker-npm/package.json
@@ -54,7 +54,7 @@
 		"prettier": "3.8.2",
 		"ts-jest": "29.4.6",
 		"ts-node": "10.9.2",
-		"typescript": "5.9.3",
+		"typescript": "6.0.2",
 		"typescript-eslint": "8.56.1",
 		"yargs": "18.0.0"
 	}

--- a/src/servicebroker-npm/package.json
+++ b/src/servicebroker-npm/package.json
@@ -52,7 +52,7 @@
 		"nerdbank-gitversioning": "3.9.50",
 		"nyc": "18.0.0",
 		"prettier": "3.8.3",
-		"ts-jest": "29.4.6",
+		"ts-jest": "29.4.9",
 		"ts-node": "10.9.2",
 		"typescript": "5.9.3",
 		"typescript-eslint": "8.56.1",

--- a/src/servicebroker-npm/src/IDisposable.ts
+++ b/src/servicebroker-npm/src/IDisposable.ts
@@ -8,7 +8,7 @@ export interface IDisposable {
 	dispose(): void
 }
 
-export module IDisposable {
+export namespace IDisposable {
 	/**
 	 * Tests whether a given object is disposable.
 	 * @param value the value to be tested.

--- a/src/servicebroker-npm/src/constants.ts
+++ b/src/servicebroker-npm/src/constants.ts
@@ -33,7 +33,7 @@ export enum RemoteServiceConnections {
 	ClrActivation = 1 << 3, // this is represented as 0x4 in .NET, keep it like that for consistency.
 }
 
-export module RemoteServiceConnections {
+export namespace RemoteServiceConnections {
 	export function contains(connections: RemoteServiceConnections | string, subset: RemoteServiceConnections) {
 		if (typeof connections === 'string') {
 			connections = parse(connections)

--- a/src/servicebroker-npm/src/jsonRpc/MarshalableObject.ts
+++ b/src/servicebroker-npm/src/jsonRpc/MarshalableObject.ts
@@ -59,7 +59,7 @@ export interface RpcMarshalable {
 	readonly _jsonRpcOptionalInterfaces?: number[]
 }
 
-export module RpcMarshalable {
+export namespace RpcMarshalable {
 	export function is(value: any): value is RpcMarshalable {
 		const candidate = value as RpcMarshalable | undefined
 		return typeof candidate?._jsonRpcMarshalableLifetime === 'string'
@@ -121,7 +121,7 @@ export interface MarshaledObjectProxy extends IDisposable {
 	_jsonrpcMarshaledHandle: number
 }
 
-export module MarshaledObjectProxy {
+export namespace MarshaledObjectProxy {
 	export function is(value: any): value is MarshaledObjectProxy {
 		const valueCandidate = value as MarshaledObjectProxy | undefined
 		return typeof valueCandidate?._jsonrpcMarshaledHandle === 'number'
@@ -166,7 +166,7 @@ function getJsonConnectionMarshalingTracker(messageConnection: MessageConnection
 	return jsonConnectionWithCounter._marshaledObjectTracker
 }
 
-export module IJsonRpcMarshaledObject {
+export namespace IJsonRpcMarshaledObject {
 	/**
 	 * Tests whether a given object implements {@link IJsonRpcMarshaledObject}.
 	 * @param value the value to be tested.

--- a/src/servicebroker-npm/tsconfig.json
+++ b/src/servicebroker-npm/tsconfig.json
@@ -13,7 +13,8 @@
 		"strict": true,
 		"strictFunctionTypes": true,
 		"strictNullChecks": true,
-		"target": "ES2022"
+		"target": "ES2022",
+		"types": ["jest", "node"]
 	},
 	"exclude": [
 		"node_modules",

--- a/src/servicebroker-npm/yarn.lock
+++ b/src/servicebroker-npm/yarn.lock
@@ -3112,7 +3112,7 @@ __metadata:
     jiti:
       optional: true
   bin:
-    eslint: bin/eslint.js
+    eslint: ./bin/eslint.js
   checksum: 10/583589ed96922aad9507c94339e843c8929c297d505ae7d70579cef56b435a10d8a48d24616eb4fb53fbe75d8655adb8e44add5d5b2bca100148d31d890ab3a4
   languageName: node
   linkType: hard
@@ -3534,7 +3534,7 @@ __metadata:
     package-json-from-dist: "npm:^1.0.0"
     path-scurry: "npm:^1.11.1"
   bin:
-    glob: dist/esm/bin.mjs
+    glob: ./dist/esm/bin.mjs
   checksum: 10/ab3bccfefcc0afaedbd1f480cd0c4a2c0e322eb3f0aa7ceaa31b3f00b825069f17cf0f1fc8b6f256795074b903f37c0ade37ddda6a176aa57f1c2bbfe7240653
   languageName: node
   linkType: hard
@@ -4990,7 +4990,7 @@ __metadata:
   version: 0.3.4
   resolution: "napi-postinstall@npm:0.3.4"
   bin:
-    napi-postinstall: lib/cli.js
+    napi-postinstall: ./lib/cli.js
   checksum: 10/5541381508f9e1051ff3518701c7130ebac779abb3a1ffe9391fcc3cab4cc0569b0ba0952357db3f6b12909c3bb508359a7a60261ffd795feebbdab967175832
   languageName: node
   linkType: hard
@@ -5154,7 +5154,7 @@ __metadata:
     test-exclude: "npm:^8.0.0"
     yargs: "npm:^15.0.2"
   bin:
-    nyc: bin/nyc.js
+    nyc: ./bin/nyc.js
   checksum: 10/f1723981b9cadc574c79fa53ba9b111023c95e4634fd7c740d9a1f0c70d890c9ce129bae8aea9ec14695dde04e5332f1eb803c0a46bd2b34efebd00f7017585b
   languageName: node
   linkType: hard
@@ -5393,7 +5393,7 @@ __metadata:
   version: 3.8.2
   resolution: "prettier@npm:3.8.2"
   bin:
-    prettier: bin/prettier.cjs
+    prettier: ./bin/prettier.cjs
   checksum: 10/fd784175bc600c07eb2c44d7ec4ee7133f95f26492adad61b6a15c06f438b858181faf096ab74163d7f49500ad80cff4479c6abb084e161a2e85a9df5974ecd1
   languageName: node
   linkType: hard
@@ -5586,7 +5586,7 @@ __metadata:
     glob: "npm:^13.0.3"
     package-json-from-dist: "npm:^1.0.1"
   bin:
-    rimraf: dist/esm/bin.mjs
+    rimraf: ./dist/esm/bin.mjs
   checksum: 10/dd98ec2ad7cd2cccae1c7110754d472eac8edb2bab8a8b057dce04edfe1433dab246a889b3fd85a66c78ca81caa1429caa0e736c7647f6832b04fd5d4dfb8ab8
   languageName: node
   linkType: hard
@@ -6173,8 +6173,8 @@ __metadata:
   version: 6.0.2
   resolution: "typescript@npm:6.0.2"
   bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
+    tsc: ./bin/tsc
+    tsserver: ./bin/tsserver
   checksum: 10/b9fc2fcee7ee8e5ca6f5138181964550531e18e2d20ecb71b802d4d495881e3444e0ef94cbb6e84eb2ba41e913f6feae3ca33cc722b32e6e6dfadb32d23b80e6
   languageName: node
   linkType: hard
@@ -6183,8 +6183,8 @@ __metadata:
   version: 6.0.2
   resolution: "typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>::version=6.0.2&hash=5786d5"
   bin:
-    tsc: bin/tsc
-    tsserver: bin/tsserver
+    tsc: ./bin/tsc
+    tsserver: ./bin/tsserver
   checksum: 10/e5501dfcf8c5b6b9a61f6fa53decc40187cebe3a2b7b2bd51c615007ad4cf6d58298461fef63294f6be9d5f2f33019b2a2e2bf02d9cb7d7f6ec94372bf24ffa2
   languageName: node
   linkType: hard

--- a/src/servicebroker-npm/yarn.lock
+++ b/src/servicebroker-npm/yarn.lock
@@ -1215,7 +1215,7 @@ __metadata:
     string-hash: "npm:^1.1.3"
     ts-jest: "npm:29.4.6"
     ts-node: "npm:10.9.2"
-    typescript: "npm:5.9.3"
+    typescript: "npm:6.0.2"
     typescript-eslint: "npm:8.56.1"
     vscode-jsonrpc: "npm:^8.1.0"
     yargs: "npm:18.0.0"
@@ -6169,23 +6169,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typescript@npm:5.9.3":
-  version: 5.9.3
-  resolution: "typescript@npm:5.9.3"
+"typescript@npm:6.0.2":
+  version: 6.0.2
+  resolution: "typescript@npm:6.0.2"
   bin:
-    tsc: ./bin/tsc
-    tsserver: ./bin/tsserver
-  checksum: 10/c089d9d3da2729fd4ac517f9b0e0485914c4b3c26f80dc0cffcb5de1719a17951e92425d55db59515c1a7ddab65808466debb864d0d56dcf43f27007d0709594
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/b9fc2fcee7ee8e5ca6f5138181964550531e18e2d20ecb71b802d4d495881e3444e0ef94cbb6e84eb2ba41e913f6feae3ca33cc722b32e6e6dfadb32d23b80e6
   languageName: node
   linkType: hard
 
-"typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>":
-  version: 5.9.3
-  resolution: "typescript@patch:typescript@npm%3A5.9.3#optional!builtin<compat/typescript>::version=5.9.3&hash=5786d5"
+"typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>":
+  version: 6.0.2
+  resolution: "typescript@patch:typescript@npm%3A6.0.2#optional!builtin<compat/typescript>::version=6.0.2&hash=5786d5"
   bin:
-    tsc: ./bin/tsc
-    tsserver: ./bin/tsserver
-  checksum: 10/696e1b017bc2635f4e0c94eb4435357701008e2f272f553d06e35b494b8ddc60aa221145e286c28ace0c89ee32827a28c2040e3a69bdc108b1a5dc8fb40b72e3
+    tsc: bin/tsc
+    tsserver: bin/tsserver
+  checksum: 10/e5501dfcf8c5b6b9a61f6fa53decc40187cebe3a2b7b2bd51c615007ad4cf6d58298461fef63294f6be9d5f2f33019b2a2e2bf02d9cb7d7f6ec94372bf24ffa2
   languageName: node
   linkType: hard
 

--- a/src/servicebroker-npm/yarn.lock
+++ b/src/servicebroker-npm/yarn.lock
@@ -1213,7 +1213,7 @@ __metadata:
     prettier: "npm:3.8.3"
     strict-event-emitter-types: "npm:^2.0.0"
     string-hash: "npm:^1.1.3"
-    ts-jest: "npm:29.4.6"
+    ts-jest: "npm:29.4.9"
     ts-node: "npm:10.9.2"
     typescript: "npm:5.9.3"
     typescript-eslint: "npm:8.56.1"
@@ -3604,9 +3604,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.7.8":
-  version: 4.7.8
-  resolution: "handlebars@npm:4.7.8"
+"handlebars@npm:^4.7.9":
+  version: 4.7.9
+  resolution: "handlebars@npm:4.7.9"
   dependencies:
     minimist: "npm:^1.2.5"
     neo-async: "npm:^2.6.2"
@@ -3618,7 +3618,7 @@ __metadata:
       optional: true
   bin:
     handlebars: bin/handlebars
-  checksum: 10/bd528f4dd150adf67f3f857118ef0fa43ff79a153b1d943fa0a770f2599e38b25a7a0dbac1a3611a4ec86970fd2325a81310fb788b5c892308c9f8743bd02e11
+  checksum: 10/e755433d652e8a15fc02f83d7478e652359e7a4d354c4328818853ed4f8a39d4a09e1d22dad3c7213c5240864a65b3c840970b8b181745575dd957dd258f2b8d
   languageName: node
   linkType: hard
 
@@ -5625,6 +5625,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"semver@npm:^7.7.4":
+  version: 7.8.0
+  resolution: "semver@npm:7.8.0"
+  bin:
+    semver: bin/semver.js
+  checksum: 10/039a8f68a581c03c1ac17c990316da57a79a93af9b109b712739c50cd4d464079f7e3fee31c008b472e390c7ba48a11ed2b86e91d8602bf06059d4a266db1426
+  languageName: node
+  linkType: hard
+
 "set-blocking@npm:^2.0.0":
   version: 2.0.0
   resolution: "set-blocking@npm:2.0.0"
@@ -6016,17 +6025,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ts-jest@npm:29.4.6":
-  version: 29.4.6
-  resolution: "ts-jest@npm:29.4.6"
+"ts-jest@npm:29.4.9":
+  version: 29.4.9
+  resolution: "ts-jest@npm:29.4.9"
   dependencies:
     bs-logger: "npm:^0.2.6"
     fast-json-stable-stringify: "npm:^2.1.0"
-    handlebars: "npm:^4.7.8"
+    handlebars: "npm:^4.7.9"
     json5: "npm:^2.2.3"
     lodash.memoize: "npm:^4.1.2"
     make-error: "npm:^1.3.6"
-    semver: "npm:^7.7.3"
+    semver: "npm:^7.7.4"
     type-fest: "npm:^4.41.0"
     yargs-parser: "npm:^21.1.1"
   peerDependencies:
@@ -6036,7 +6045,7 @@ __metadata:
     babel-jest: ^29.0.0 || ^30.0.0
     jest: ^29.0.0 || ^30.0.0
     jest-util: ^29.0.0 || ^30.0.0
-    typescript: ">=4.3 <6"
+    typescript: ">=4.3 <7"
   peerDependenciesMeta:
     "@babel/core":
       optional: true
@@ -6052,7 +6061,7 @@ __metadata:
       optional: true
   bin:
     ts-jest: cli.js
-  checksum: 10/e0ff9e13f684166d5331808b288043b8054f49a1c2970480a92ba3caec8d0ff20edd092f2a4e7a3ad8fcb9ba4d674bee10ec7ee75046d8066bbe43a7d16cf72e
+  checksum: 10/f5e81b1e13fff08da5b92d5a72f984f3393f40df73a1ae54473a780436b95dddb1452c78256e6d70a701c09ea427449657a5fbb3d142dc7e7a82eb192e80c3db
   languageName: node
   linkType: hard
 

--- a/src/servicebroker-npm/yarn.lock
+++ b/src/servicebroker-npm/yarn.lock
@@ -2316,15 +2316,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.2":
-  version: 5.0.3
-  resolution: "brace-expansion@npm:5.0.3"
-  dependencies:
-    balanced-match: "npm:^4.0.2"
-  checksum: 10/8ba7deae4ca333d52418d2cde3287ac23f44f7330d92c3ecd96a8941597bea8aab02227bd990944d6711dd549bcc6e550fe70be5d94aa02e2fdc88942f480c9b
-  languageName: node
-  linkType: hard
-
 "brace-expansion@npm:^5.0.5":
   version: 5.0.5
   resolution: "brace-expansion@npm:5.0.5"
@@ -4832,16 +4823,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"minimatch@npm:^10.2.2":
-  version: 10.2.4
-  resolution: "minimatch@npm:10.2.4"
-  dependencies:
-    brace-expansion: "npm:^5.0.2"
-  checksum: 10/aea4874e521c55bb60744685bbffe3d152e5460f84efac3ea936e6bbe2ceba7deb93345fec3f9bb17f7b6946776073a64d40ae32bf5f298ad690308121068a1f
-  languageName: node
-  linkType: hard
-
-"minimatch@npm:^10.2.4":
+"minimatch@npm:^10.2.2, minimatch@npm:^10.2.4":
   version: 10.2.5
   resolution: "minimatch@npm:10.2.5"
   dependencies:

--- a/src/servicebroker-npm/yarn.lock
+++ b/src/servicebroker-npm/yarn.lock
@@ -3615,7 +3615,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"handlebars@npm:^4.7.8, handlebars@npm:^4.7.9":
+"handlebars@npm:^4.7.9":
   version: 4.7.9
   resolution: "handlebars@npm:4.7.9"
   dependencies:

--- a/src/servicebroker-npm/yarn.lock
+++ b/src/servicebroker-npm/yarn.lock
@@ -3374,9 +3374,9 @@ __metadata:
   linkType: hard
 
 "flatted@npm:^3.2.9":
-  version: 3.3.3
-  resolution: "flatted@npm:3.3.3"
-  checksum: 10/8c96c02fbeadcf4e8ffd0fa24983241e27698b0781295622591fc13585e2f226609d95e422bcf2ef044146ffacb6b68b1f20871454eddf75ab3caa6ee5f4a1fe
+  version: 3.4.2
+  resolution: "flatted@npm:3.4.2"
+  checksum: 10/a9e78fe5c2c1fcd98209a015ccee3a6caa953e01729778e83c1fe92e68601a63e1e69cd4e573010ca99eaf585a581b80ccf1018b99283e6cbc2117bcba1e030f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- **Update dependency typescript to v6**
- **patch yarn.lock**
- **Adapt to NPM changes**
- **Update dependency dotnet-coverage to v18.7.0**
- **Update dependency ts-jest to v29.4.9**
- **chore: requeue CI after authenticated yarn restore**
- **chore: requeue CI after authenticated yarn restore**
- **chore: requeue CI after authenticated yarn restore**
- **fix: update yarn lockfile for immutable CI install**
- **chore: requeue CI after lockfile validation**
- **chore: requeue CI after lockfile validation**
- **Bump flatted from 3.3.3 to 3.4.2 in /src/servicebroker-npm**
- **Bump minimatch from 3.0.8 to 10.2.5 in /src/servicebroker-npm**
