### PR TITLE
Use source-generated metadata view for IBrokeredServicesExportMetadata

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,7 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="$(CodefixTestingVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.SourceGenerators.Testing.XUnit" Version="$(CodefixTestingVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic.CodeFix.Testing.XUnit" Version="$(CodefixTestingVersion)" />
-    <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="18.3.62" />
+    <PackageVersion Include="Microsoft.VisualStudio.Composition" Version="18.9.15" />
     <PackageVersion Include="Microsoft.VisualStudio.Interop" Version="18.7.411" />
     <PackageVersion Include="Microsoft.VisualStudio.RpcContracts" Version="18.7.384" />
     <PackageVersion Include="Microsoft.VisualStudio.Utilities" Version="18.7.411" />

--- a/src/Microsoft.ServiceHub.Framework/Container/ExportBrokeredServiceAttribute.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/ExportBrokeredServiceAttribute.cs
@@ -5,6 +5,7 @@ using System.Collections.Immutable;
 using System.ComponentModel;
 using System.ComponentModel.Composition;
 using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Composition;
 
 namespace Microsoft.VisualStudio.Shell.ServiceBroker;
 
@@ -131,7 +132,8 @@ public class ExportBrokeredServiceAttribute : ExportAttribute
 /// set to <see langword="true"/>.
 /// </devremarks>
 #pragma warning disable SA1201 // Elements should appear in the correct order
-internal interface IBrokeredServicesExportMetadata
+[MetadataView]
+internal partial interface IBrokeredServicesExportMetadata
 #pragma warning restore SA1201 // Elements should appear in the correct order
 {
 	/// <inheritdoc cref="ExportBrokeredServiceAttribute.ServiceName"/>


### PR DESCRIPTION
Use source-generated metadata view for IBrokeredServicesExportMetadata to eliminate its jitting on startup.