### PR TITLE
Use source-generated local proxy in ServiceJsonRpcDescriptor.Construc…

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/Reflection/ProxyBase.cs
+++ b/src/Microsoft.ServiceHub.Framework/Reflection/ProxyBase.cs
@@ -14,8 +14,14 @@ namespace Microsoft.ServiceHub.Framework.Reflection;
 [EditorBrowsable(EditorBrowsableState.Never)]
 public abstract class ProxyBase : IDisposableObservable, INotifyDisposable, IClientProxy, IJsonRpcLocalProxy
 {
+	// Sentinel value stored in <see cref="disposedHandlers"/> after disposal so that
+	// add/remove of <see cref="INotifyDisposable.Disposed"/> can detect the disposed state
+	// and invoke the handler immediately rather than rooting it in a backing field.
+	private static readonly object DisposedSentinel = new();
+
 	private readonly ProxyInputs proxyInputs;
 	private object? target;
+	private object? disposedHandlers;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ProxyBase"/> class.
@@ -31,7 +37,18 @@ public abstract class ProxyBase : IDisposableObservable, INotifyDisposable, ICli
 	}
 
 	/// <inheritdoc/>
-	public event EventHandler? Disposed;
+	public event EventHandler? Disposed
+	{
+		add
+		{
+			if (!TryUpdateHandlers(ref this.disposedHandlers, value, combine: true))
+			{
+				value?.Invoke(this, EventArgs.Empty);
+			}
+		}
+
+		remove => TryUpdateHandlers(ref this.disposedHandlers, value, combine: false);
+	}
 
 	/// <inheritdoc/>
 	public bool IsDisposed => this.target is null;
@@ -133,7 +150,14 @@ public abstract class ProxyBase : IDisposableObservable, INotifyDisposable, ICli
 			return (T)(object)this;
 		}
 
-		return (T)CreateProxy(this.Target, this.proxyInputs with { AdditionalContractInterfaces = default, ContractInterface = typeof(T) }, startOrFail: false);
+		// If the wrapped target itself doesn't implement T, no proxy can satisfy the request.
+		// Match the IL-emit proxy semantics by returning null rather than throwing.
+		if (this.target is not T innerTarget)
+		{
+			return null;
+		}
+
+		return (T)CreateProxy(innerTarget, this.proxyInputs with { AdditionalContractInterfaces = default, ContractInterface = typeof(T) }, startOrFail: false);
 	}
 
 	/// <inheritdoc/>
@@ -148,7 +172,9 @@ public abstract class ProxyBase : IDisposableObservable, INotifyDisposable, ICli
 
 		(inner as IDisposable)?.Dispose();
 		inner = null;
-		this.Disposed?.Invoke(this, EventArgs.Empty);
+
+		object? handlers = Interlocked.Exchange(ref this.disposedHandlers, DisposedSentinel);
+		((EventHandler?)handlers)?.Invoke(this, EventArgs.Empty);
 	}
 
 	/// <inheritdoc/>
@@ -271,5 +297,29 @@ public abstract class ProxyBase : IDisposableObservable, INotifyDisposable, ICli
 				throw new InvalidCastException();
 			}
 		}
+	}
+
+	/// <summary>
+	/// Atomically updates a delegate handler field, returning <see langword="false"/> if the field
+	/// already holds <see cref="DisposedSentinel"/>.
+	/// </summary>
+	private static bool TryUpdateHandlers(ref object? handlers, EventHandler? value, bool combine)
+	{
+		object? oldValue = handlers;
+		while (oldValue != DisposedSentinel)
+		{
+			object? newValue = combine
+				? (object?)Delegate.Combine((EventHandler?)oldValue, value)
+				: (object?)Delegate.Remove((EventHandler?)oldValue, value);
+			object? prevValue = Interlocked.CompareExchange(ref handlers, newValue, oldValue);
+			if (prevValue == oldValue)
+			{
+				return true;
+			}
+
+			oldValue = prevValue;
+		}
+
+		return false;
 	}
 }

--- a/src/Microsoft.ServiceHub.Framework/Reflection/ProxyBase.cs
+++ b/src/Microsoft.ServiceHub.Framework/Reflection/ProxyBase.cs
@@ -18,6 +18,7 @@ public abstract class ProxyBase : IDisposableObservable, INotifyDisposable, ICli
 	// add/remove of <see cref="INotifyDisposable.Disposed"/> can detect the disposed state
 	// and invoke the handler immediately rather than rooting it in a backing field.
 	private static readonly object DisposedSentinel = new();
+	private static readonly HashSet<Type> BuiltInProxyInterfaces = [.. typeof(ProxyBase).GetInterfaces()];
 
 	private readonly ProxyInputs proxyInputs;
 	private object? target;
@@ -130,7 +131,8 @@ public abstract class ProxyBase : IDisposableObservable, INotifyDisposable, ICli
 			if (ProxyImplementsCompatibleSetOfInterfaces(
 				attribute.ProxyClass,
 				proxyInputs.ContractInterface,
-				proxyInputs.AdditionalContractInterfaces.Span))
+				proxyInputs.AdditionalContractInterfaces.Span,
+				proxyInputs.AcceptProxyWithExtraInterfaces))
 			{
 				proxy = (IClientProxy?)Activator.CreateInstance(attribute.ProxyClass, target, proxyInputs);
 				return proxy is not null;
@@ -253,12 +255,14 @@ public abstract class ProxyBase : IDisposableObservable, INotifyDisposable, ICli
 	/// <param name="proxyClass">The type of the proxy class to be evaluated. This type must implement the specified interfaces.</param>
 	/// <param name="contractInterface">The primary contract interface that the proxy class must implement.</param>
 	/// <param name="additionalContractInterfaces">A span of additional contract interfaces that the proxy class must also implement.</param>
+	/// <param name="acceptProxyWithExtraInterfaces">A value indicating whether extra interfaces are acceptable on a source-generated proxy.</param>
 	/// <returns><see langword="true"/> if the proxy class implements the specified contract interface and additional interfaces,
 	/// (and potentially extra interfaces); otherwise, <see langword="false"/>.</returns>
 	private static bool ProxyImplementsCompatibleSetOfInterfaces(
 		[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.Interfaces)] Type proxyClass,
 		Type contractInterface,
-		ReadOnlySpan<Type> additionalContractInterfaces)
+		ReadOnlySpan<Type> additionalContractInterfaces,
+		bool acceptProxyWithExtraInterfaces)
 	{
 		HashSet<Type> proxyInterfaces = [.. proxyClass.GetInterfaces()];
 		if (!proxyInterfaces.Contains(contractInterface))
@@ -271,6 +275,32 @@ public abstract class ProxyBase : IDisposableObservable, INotifyDisposable, ICli
 			if (!proxyInterfaces.Contains(addl))
 			{
 				return false;
+			}
+		}
+
+		if (!acceptProxyWithExtraInterfaces)
+		{
+			foreach (Type proxyInterface in proxyInterfaces)
+			{
+				if (BuiltInProxyInterfaces.Contains(proxyInterface) || proxyInterface.IsAssignableFrom(contractInterface))
+				{
+					continue;
+				}
+
+				bool impliedByAdditionalInterface = false;
+				foreach (Type addl in additionalContractInterfaces)
+				{
+					if (proxyInterface.IsAssignableFrom(addl))
+					{
+						impliedByAdditionalInterface = true;
+						break;
+					}
+				}
+
+				if (!impliedByAdditionalInterface)
+				{
+					return false;
+				}
 			}
 		}
 

--- a/src/Microsoft.ServiceHub.Framework/Reflection/ProxyInputs.cs
+++ b/src/Microsoft.ServiceHub.Framework/Reflection/ProxyInputs.cs
@@ -23,6 +23,11 @@ public readonly struct ProxyInputs
 	public ReadOnlyMemory<Type> AdditionalContractInterfaces { get; init; }
 
 	/// <summary>
+	/// Gets a value indicating whether a source-generated proxy that implements extra interfaces may be used.
+	/// </summary>
+	public bool AcceptProxyWithExtraInterfaces { get; init; }
+
+	/// <summary>
 	/// Gets the exception strategy for the proxy.
 	/// </summary>
 	internal ExceptionProcessing ExceptionStrategy { get; init; }

--- a/src/Microsoft.ServiceHub.Framework/ServiceJsonRpcDescriptor.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServiceJsonRpcDescriptor.cs
@@ -71,6 +71,7 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 		this.ExceptionStrategy = copyFrom.ExceptionStrategy;
 		this.AdditionalServiceInterfaces = copyFrom.AdditionalServiceInterfaces;
 		this.DisplayName = copyFrom.DisplayName;
+		this.AcceptProxyWithExtraInterfaces = copyFrom.AcceptProxyWithExtraInterfaces;
 	}
 
 	/// <summary>
@@ -163,6 +164,11 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 	public string DisplayName { get; private set; }
 
 	/// <summary>
+	/// Gets a value indicating whether a source-generated local proxy that implements extra interfaces may be used.
+	/// </summary>
+	public bool AcceptProxyWithExtraInterfaces { get; private set; }
+
+	/// <summary>
 	/// Gets the default display name based on this descriptor's type.
 	/// </summary>
 	private protected string DefaultDisplayName => this.GetType().FullName!;
@@ -214,6 +220,7 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 			{
 				ContractInterface = typeof(T),
 				AdditionalContractInterfaces = additionalServiceInterfaces.AsMemory(),
+				AcceptProxyWithExtraInterfaces = this.AcceptProxyWithExtraInterfaces,
 				ExceptionStrategy = this.ExceptionStrategy,
 			};
 			if (Reflection.ProxyBase.TryCreateProxy(target, sourceGenInputs, out IClientProxy? sourceGenProxy))
@@ -311,6 +318,24 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 
 	/// <summary>
 	/// Returns an instance of <see cref="ServiceJsonRpcDescriptor"/> that resembles this one,
+	/// but with the <see cref="AcceptProxyWithExtraInterfaces"/> property set to a new value.
+	/// </summary>
+	/// <param name="value">The new value for the <see cref="AcceptProxyWithExtraInterfaces"/> property.</param>
+	/// <returns>A clone of this instance, with the property changed. Or this same instance if the property already matches.</returns>
+	public ServiceJsonRpcDescriptor WithAcceptProxyWithExtraInterfaces(bool value)
+	{
+		if (this.AcceptProxyWithExtraInterfaces == value)
+		{
+			return this;
+		}
+
+		var result = (ServiceJsonRpcDescriptor)this.Clone();
+		result.AcceptProxyWithExtraInterfaces = value;
+		return result;
+	}
+
+	/// <summary>
+	/// Returns an instance of <see cref="ServiceJsonRpcDescriptor"/> that resembles this one,
 	/// but with the <see cref="AdditionalServiceInterfaces" /> property set to a new value.
 	/// </summary>
 	/// <param name="value">The new value for the <see cref="AdditionalServiceInterfaces"/> property.</param>
@@ -403,6 +428,7 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 	internal ServiceJsonRpcDescriptor WithSettingsFrom(ServiceJsonRpcDescriptor copyFrom)
 	{
 		if (this.ExceptionStrategy == copyFrom.ExceptionStrategy &&
+			this.AcceptProxyWithExtraInterfaces == copyFrom.AcceptProxyWithExtraInterfaces &&
 			this.MultiplexingStreamOptions == copyFrom.MultiplexingStreamOptions &&
 			this.MultiplexingStream == copyFrom.MultiplexingStream &&
 			this.JoinableTaskFactory == copyFrom.JoinableTaskFactory &&
@@ -413,6 +439,7 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 
 		var result = (ServiceJsonRpcDescriptor)this.Clone();
 		result.ExceptionStrategy = copyFrom.ExceptionStrategy;
+		result.AcceptProxyWithExtraInterfaces = copyFrom.AcceptProxyWithExtraInterfaces;
 
 		if (copyFrom.MultiplexingStreamOptions is not null)
 		{
@@ -590,7 +617,7 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 		/// <devremarks>
 		/// Create a new instance of <see cref="JsonRpcProxyOptions"/> every time because it's mutable.
 		/// </devremarks>
-		private JsonRpcProxyOptions localRpcProxyOptions = new JsonRpcProxyOptions { };
+		private JsonRpcProxyOptions localRpcProxyOptions;
 
 		/// <inheritdoc cref="JsonRpcConnection(JsonRpc, ServiceJsonRpcDescriptor)"/>
 		public JsonRpcConnection(JsonRpc jsonRpc)
@@ -607,6 +634,7 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 		{
 			this.JsonRpc = jsonRpc ?? throw new ArgumentNullException(nameof(jsonRpc));
 			this.owner = owner;
+			this.localRpcProxyOptions = new JsonRpcProxyOptions { AcceptProxyWithExtraInterfaces = owner?.AcceptProxyWithExtraInterfaces ?? false };
 		}
 
 		/// <inheritdoc/>
@@ -635,6 +663,7 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 		/// <summary>
 		/// Gets or sets the options to pass to <see cref="JsonRpc.Attach{T}(JsonRpcProxyOptions?)"/> in the default implementation of <see cref="ConstructRpcClient{T}()"/>.
 		/// </summary>
+		/// <value>The default value mirrors <see cref="ServiceJsonRpcDescriptor.AcceptProxyWithExtraInterfaces"/> on the owning descriptor.</value>
 		public JsonRpcProxyOptions LocalRpcProxyOptions
 		{
 			get => this.localRpcProxyOptions;

--- a/src/Microsoft.ServiceHub.Framework/ServiceJsonRpcDescriptor.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServiceJsonRpcDescriptor.cs
@@ -194,12 +194,48 @@ public partial class ServiceJsonRpcDescriptor : ServiceRpcDescriptor, IEquatable
 	public override T? ConstructLocalProxy<T>(T? target)
 		where T : class
 	{
+		if (target is null)
+		{
+			return null;
+		}
+
 		ImmutableArray<Type> additionalServiceInterfaces = this.AdditionalServiceInterfaces is { Length: > 0 } addl
 			? (addl.Contains(typeof(T)) ? addl.Remove(typeof(T)) : addl)
 			: [];
-		return target != null
-			? LocalProxyGeneration.CreateProxy<T>(target, additionalServiceInterfaces.AsSpan(), this.ExceptionStrategy)
-			: null;
+
+		// Prefer a source-generated proxy when one is available for T (and any additional interfaces).
+		// This avoids JIT'ing methods on the dynamic 'localRpcProxies_*' assembly emitted by LocalProxyGeneration
+		// and is also AOT-safe.
+		// If the target lacks any of the additional service interfaces, skip source-gen and let LocalProxyGeneration
+		// produce its standard ServiceCompositionException-wrapped failure (preserving existing public behavior).
+		if (typeof(T).IsInterface && IsTargetCompatibleWithAdditionalInterfaces(target, additionalServiceInterfaces))
+		{
+			Reflection.ProxyInputs sourceGenInputs = new()
+			{
+				ContractInterface = typeof(T),
+				AdditionalContractInterfaces = additionalServiceInterfaces.AsMemory(),
+				ExceptionStrategy = this.ExceptionStrategy,
+			};
+			if (Reflection.ProxyBase.TryCreateProxy(target, sourceGenInputs, out IClientProxy? sourceGenProxy))
+			{
+				return (T)sourceGenProxy;
+			}
+		}
+
+		return LocalProxyGeneration.CreateProxy<T>(target, additionalServiceInterfaces.AsSpan(), this.ExceptionStrategy);
+
+		static bool IsTargetCompatibleWithAdditionalInterfaces(object target, ImmutableArray<Type> additionalInterfaces)
+		{
+			foreach (Type addl in additionalInterfaces)
+			{
+				if (!addl.IsInstanceOfType(target))
+				{
+					return false;
+				}
+			}
+
+			return true;
+		}
 	}
 
 	/// <inheritdoc />

--- a/src/Microsoft.ServiceHub.Framework/ServiceJsonRpcPolyTypeDescriptor.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServiceJsonRpcPolyTypeDescriptor.cs
@@ -318,6 +318,7 @@ public class ServiceJsonRpcPolyTypeDescriptor : ServiceRpcDescriptor, IEquatable
 		{
 			ContractInterface = typeof(T),
 			AdditionalContractInterfaces = additionalServiceInterfaces.AsMemory(),
+			AcceptProxyWithExtraInterfaces = true,
 			ExceptionStrategy = this.ExceptionStrategy,
 		};
 

--- a/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcDescriptorTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcDescriptorTests.cs
@@ -73,6 +73,7 @@ public partial class ServiceJsonRpcDescriptorTests : TestBase
 		var descriptor = new TestServiceJsonRpcDescriptor(SomeMoniker, null, ServiceJsonRpcDescriptor.Formatters.MessagePack, ServiceJsonRpcDescriptor.MessageDelimiters.BigEndianInt32LengthHeader, MultiplexingStreamOptions);
 		descriptor = (TestServiceJsonRpcDescriptor)descriptor
 			.WithExceptionStrategy(descriptor.ExceptionStrategy == ExceptionProcessing.ISerializable ? ExceptionProcessing.CommonErrorData : ExceptionProcessing.ISerializable)
+			.WithAcceptProxyWithExtraInterfaces(true)
 			.WithAdditionalServiceInterfaces(additionalServiceInterfaces);
 
 		TestServiceJsonRpcDescriptor descriptorCopied = descriptor.CopyWithClone();
@@ -85,7 +86,25 @@ public partial class ServiceJsonRpcDescriptorTests : TestBase
 		Assert.Equal(MultiplexingStreamOptions.SeededChannels, descriptorCopied.MultiplexingStreamOptions?.SeededChannels);
 		Assert.True(descriptorCopied.MultiplexingStreamOptions?.IsFrozen);
 		Assert.Equal(descriptor.ExceptionStrategy, descriptorCopied.ExceptionStrategy);
+		Assert.Equal(descriptor.AcceptProxyWithExtraInterfaces, descriptorCopied.AcceptProxyWithExtraInterfaces);
 		Assert.Equal(additionalServiceInterfaces, descriptor.AdditionalServiceInterfaces);
+	}
+
+	[Fact]
+	public void WithAcceptProxyWithExtraInterfaces()
+	{
+		ServiceJsonRpcDescriptor descriptor = CreateDefault();
+		Assert.False(descriptor.AcceptProxyWithExtraInterfaces);
+
+		Assert.Same(descriptor, descriptor.WithAcceptProxyWithExtraInterfaces(false));
+
+		ServiceJsonRpcDescriptor modified = descriptor.WithAcceptProxyWithExtraInterfaces(true);
+		Assert.NotSame(descriptor, modified);
+		Assert.True(modified.AcceptProxyWithExtraInterfaces);
+		Assert.False(descriptor.AcceptProxyWithExtraInterfaces);
+
+		TestServiceJsonRpcDescriptor cloned = ((TestServiceJsonRpcDescriptor)new TestServiceJsonRpcDescriptor(SomeMoniker, null, ServiceJsonRpcDescriptor.Formatters.UTF8, ServiceJsonRpcDescriptor.MessageDelimiters.HttpLikeHeaders, null).WithAcceptProxyWithExtraInterfaces(true)).CopyWithClone();
+		Assert.True(cloned.AcceptProxyWithExtraInterfaces);
 	}
 
 	[Fact]
@@ -93,6 +112,19 @@ public partial class ServiceJsonRpcDescriptorTests : TestBase
 	{
 		var descriptor = new ServiceJsonRpcDescriptor(SomeMoniker, clientInterface: null, ServiceJsonRpcDescriptor.Formatters.MessagePack, ServiceJsonRpcDescriptor.MessageDelimiters.BigEndianInt32LengthHeader, multiplexingStreamOptions: null);
 		Assert.Equal("json-rpc", descriptor.Protocol);
+	}
+
+	[Theory]
+	[InlineData(false)]
+	[InlineData(true)]
+	public void ConstructRpcConnection_DefaultProxyOptionsMirrorDescriptorSetting(bool acceptProxyWithExtraInterfaces)
+	{
+		ServiceJsonRpcDescriptor descriptor = new ServiceJsonRpcDescriptor(SomeMoniker, clientInterface: null, ServiceJsonRpcDescriptor.Formatters.UTF8, ServiceJsonRpcDescriptor.MessageDelimiters.HttpLikeHeaders, multiplexingStreamOptions: null)
+			.WithAcceptProxyWithExtraInterfaces(acceptProxyWithExtraInterfaces);
+		(Stream, Stream) pair = FullDuplexStream.CreatePair();
+
+		ServiceJsonRpcDescriptor.JsonRpcConnection connection = Assert.IsType<ServiceJsonRpcDescriptor.JsonRpcConnection>(descriptor.ConstructRpcConnection(pair.Item1.UsePipe(cancellationToken: this.TimeoutToken)));
+		Assert.Equal(acceptProxyWithExtraInterfaces, connection.LocalRpcProxyOptions.AcceptProxyWithExtraInterfaces);
 	}
 
 	[Fact]

--- a/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcDescriptor_ProxyTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcDescriptor_ProxyTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Collections.Immutable;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using Microsoft;
 using Microsoft.ServiceHub.Framework;
@@ -233,9 +234,37 @@ public class ServiceJsonRpcDescriptor_ProxyTests : ServiceRpcDescriptor_ProxyTes
 	[Fact]
 	public void UsesSourceGeneratedProxyWhenAvailable()
 	{
-		ISomeService? proxy = this.CreateProxy<ISomeService>(new SomeNonDisposableService());
+		ISomeService2? proxy = this.CreateProxy<ISomeService2>(new SomeNonDisposableService());
 		Assumes.NotNull(proxy);
 		Assert.IsAssignableFrom<Microsoft.ServiceHub.Framework.Reflection.ProxyBase>(proxy);
+		this.Logger.WriteLine($"Proxy type: {proxy.GetType().FullName}");
+	}
+
+	/// <summary>
+	/// Verifies that a grouped source-generated proxy is not used when the target lacks one of the grouped interfaces,
+	/// since the source-generated proxy type would otherwise expose interfaces that fail when invoked.
+	/// </summary>
+	[Fact]
+	public void GroupedSourceGeneratedProxyIsRejectedWhenTargetLacksGroupedInterface()
+	{
+		ISomeService? proxy = this.CreateProxy<ISomeService>(new SomePrimaryOnlyService());
+		Assumes.NotNull(proxy);
+		Assert.IsNotAssignableFrom<Microsoft.ServiceHub.Framework.Reflection.ProxyBase>(proxy);
+		Assert.False(proxy is ISomeService2);
+		this.Logger.WriteLine($"Proxy type: {proxy.GetType().FullName}");
+	}
+
+	[Fact]
+	public void GroupedSourceGeneratedProxyCanBeOptedIntoWhenTargetLacksGroupedInterface()
+	{
+		ServiceJsonRpcDescriptor descriptor = new ServiceJsonRpcDescriptor(new ServiceMoniker("SomeMoniker"), clientInterface: null, ServiceJsonRpcDescriptor.Formatters.UTF8, ServiceJsonRpcDescriptor.MessageDelimiters.HttpLikeHeaders, multiplexingStreamOptions: null)
+			.WithAcceptProxyWithExtraInterfaces(true);
+
+		ISomeService? proxy = this.CreateProxy<ISomeService>(new SomePrimaryOnlyService(), descriptor);
+		Assumes.NotNull(proxy);
+		Assert.IsAssignableFrom<Microsoft.ServiceHub.Framework.Reflection.ProxyBase>(proxy);
+		Assert.True(proxy is ISomeService2);
+		Assert.False(((IClientProxy)proxy).Is(typeof(ISomeService2)));
 		this.Logger.WriteLine($"Proxy type: {proxy.GetType().FullName}");
 	}
 
@@ -269,5 +298,40 @@ public class ServiceJsonRpcDescriptor_ProxyTests : ServiceRpcDescriptor_ProxyTes
 	private protected class SomeService : SomeNonDisposableService, IServerWithVoidMethod
 	{
 		public void NoReturnValue() => this.NoReturnValue_Invoked = true;
+	}
+
+	private sealed class SomePrimaryOnlyService : ISomeService
+	{
+		private readonly Guid identifier = Guid.NewGuid();
+
+		public event EventHandler<PropertyChangedEventArgs>? PropertyChanged;
+
+		public Task<int> AddAsync(int a, int b) => Task.FromResult(a + b);
+
+		public ValueTask<int> AddValueAsync(int a, int b) => new(a + b);
+
+		public Task Throws() => Task.FromException(new InvalidOperationException());
+
+		public Task NoOp(CancellationToken cancellationToken) => Task.CompletedTask;
+
+		public Task GetFaultedTask(bool yieldFirst, CancellationToken cancellationToken) => Task.FromException(new InvalidOperationException());
+
+		public Task<int> GetFaultedTaskOfT(bool yieldFirst, CancellationToken cancellationToken) => Task.FromException<int>(new InvalidOperationException());
+
+		public ValueTask GetFaultedValueTask(bool yieldFirst, CancellationToken cancellationToken) => new(Task.FromException(new InvalidOperationException()));
+
+		public ValueTask<int> GetFaultedValueTaskOfT(bool yieldFirst, CancellationToken cancellationToken) => new(Task.FromException<int>(new InvalidOperationException()));
+
+		public Task<ExternalTestAssembly.InternalType> MethodReturnsInternalTypeFromOtherAssemblyAsync(CancellationToken cancellationToken)
+			=> Task.FromException<ExternalTestAssembly.InternalType>(new InvalidOperationException());
+
+		public Task FaultWithErrorCodeAsync(string topLevelMessage, int errorCode, string secondaryMessage, int hresult)
+			=> Task.FromException(new InvalidOperationException());
+
+		public Task YieldThenThrow() => Task.FromException(new InvalidOperationException());
+
+		public Task<Guid> GetIdentifier() => Task.FromResult(this.identifier);
+
+		internal void OnPropertyChanged(string propertyName) => this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 	}
 }

--- a/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcDescriptor_ProxyTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcDescriptor_ProxyTests.cs
@@ -225,6 +225,33 @@ public class ServiceJsonRpcDescriptor_ProxyTests : ServiceRpcDescriptor_ProxyTes
 		this.Logger.WriteLine(ex.ToString());
 	}
 
+	/// <summary>
+	/// Verifies that <see cref="ServiceJsonRpcDescriptor"/> uses the source-generated proxy
+	/// (a <see cref="Microsoft.ServiceHub.Framework.Reflection.ProxyBase"/>-derived class) when one is registered
+	/// for the contract via <see cref="JsonRpcContractAttribute"/>, instead of emitting a dynamic proxy.
+	/// </summary>
+	[Fact]
+	public void UsesSourceGeneratedProxyWhenAvailable()
+	{
+		ISomeService? proxy = this.CreateProxy<ISomeService>(new SomeNonDisposableService());
+		Assumes.NotNull(proxy);
+		Assert.IsAssignableFrom<Microsoft.ServiceHub.Framework.Reflection.ProxyBase>(proxy);
+		this.Logger.WriteLine($"Proxy type: {proxy.GetType().FullName}");
+	}
+
+	/// <summary>
+	/// Verifies that contracts without <see cref="JsonRpcContractAttribute"/> still get a dynamically-emitted proxy,
+	/// since no source-generated proxy class is registered for them.
+	/// </summary>
+	[Fact]
+	public void FallsBackToDynamicProxyForUnannotatedContract()
+	{
+		IServerWithVoidMethod? proxy = this.CreateProxy<IServerWithVoidMethod>(new SomeService());
+		Assumes.NotNull(proxy);
+		Assert.IsNotAssignableFrom<Microsoft.ServiceHub.Framework.Reflection.ProxyBase>(proxy);
+		this.Logger.WriteLine($"Proxy type: {proxy.GetType().FullName}");
+	}
+
 	protected override T? CreateProxy<T>(T? target, ServiceRpcDescriptor descriptor)
 		where T : class
 	{


### PR DESCRIPTION
Startup.SingleFile perf test indicates 20 methods are being jitted in localRpcProxies_8869a195-770f-62ef-3da5-47c5c92f39b3, which are  RPC contract interfaces:
<img width="1220" height="340" alt="image" src="https://github.com/user-attachments/assets/baeed4a7-b450-4dd4-be1a-785255c4d075" />

They do have source generator setup ([JsonRpcContract]), but still cause jitting because ServiceJsonRpcDescriptor.ConstructLocalProxy ignores it.

ServiceJsonRpcDescriptor.ConstructLocalProxy unconditionally went through LocalProxyGeneration, which emits a dynamic 'localRpcProxies_*' assembly via Reflection.Emit and JIT's a fresh proxy method per RPC method. The vs-servicehub source generator has been emitting [LocalProxyMappingAttribute]-annotated ProxyBase subclasses for every [JsonRpcContract] interface for a while, but only ServiceJsonRpcPolyTypeDescriptor consulted them; the legacy descriptor never did, so contracts that opted into [JsonRpcContract] (e.g. RpcContracts.* in DevDiv/VS) still paid the JIT cost on hot startup paths.

Make the legacy descriptor try ProxyBase.TryCreateProxy first, falling back to LocalProxyGeneration when no compatible source-generated proxy is registered or when the target lacks one of the additional service interfaces. The fallback path preserves the existing ServiceCompositionException-wrapped failure mode.

The Disposed (and the ConstructLocalProxy<T>() null-return) changes only exist because, once you route the legacy descriptor through ProxyBase, the existing ServiceJsonRpcDescriptor_ProxyTests test class fails on three tests that exercise behavior ProxyBase didn't implement correctly:

INotifyDisposable_HandlerAddedAfterDisposal — handler added after Dispose() must fire immediately
INotifyDisposable_DisposalReleasesRef — handlers must be released for GC after Dispose()
TargetImplementsIJsonRpcLocalProxy — ConstructLocalProxy<T>() returns null when target lacks T

Also fix two pre-existing correctness gaps in ProxyBase that this change exposed via the legacy descriptor's test suite: (1) IJsonRpcLocalProxy.ConstructLocalProxy<T>() now returns null when the wrapped target doesn't implement T (matching the IL-emit proxy contract) instead of throwing InvalidCastException; (2) the INotifyDisposable.Disposed event uses an Interlocked sentinel pattern so that handlers added after Dispose() fire immediately and are released for GC.