### PR TITLE
Add analyzer to encourage use of WithRpcTargetMetadata

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,7 +2,8 @@
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": [
 		"github>microsoft/vs-renovate-presets:microbuild",
-		"github>microsoft/vs-renovate-presets:vs_main_dependencies"
+		"github>microsoft/vs-renovate-presets:vs_main_dependencies",
+		"github>microsoft/vs-renovate-presets:dotnet_packages_LTS"
 	],
 	"packageRules": [
 		{

--- a/Directory.Packages.Analyzers.props
+++ b/Directory.Packages.Analyzers.props
@@ -1,18 +1,16 @@
 <Project>
+  <!-- These versions carefully chosen to support VS 2022 Update 14 and the .NET 8 SDK. -->
   <PropertyGroup>
-    <CodeAnalysisVersionForAnalyzers>4.14.0</CodeAnalysisVersionForAnalyzers>
+    <CodeAnalysisVersionForAnalyzers>4.11.0</CodeAnalysisVersionForAnalyzers>
   </PropertyGroup>
   <ItemGroup>
-    <!-- These versions carefully chosen to support VS 2022 Update 14. -->
-    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="$(CodeAnalysisVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.Common" Version="$(CodeAnalysisVersionForAnalyzers)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(CodeAnalysisVersionForAnalyzers)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="$(MicrosoftCodeAnalysisAnalyzersVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(CodeAnalysisVersion)" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.VisualBasic" Version="$(CodeAnalysisVersionForAnalyzers)" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(CodeAnalysisVersionForAnalyzers)" />
-    <PackageVersion Update="System.Collections.Immutable" Version="9.0.0" />
     <PackageVersion Update="System.Memory" Version="4.5.5" />
-    <PackageVersion Update="System.Reflection.Metadata" Version="9.0.0" />
+    <PackageVersion Update="System.Reflection.Metadata" Version="8.0.0" />
     <PackageVersion Update="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
-    <PackageVersion Update="System.Text.Json" Version="9.0.0" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -35,10 +35,10 @@
     <PackageVersion Include="Nerdbank.Streams" Version="2.13.16" />
     <PackageVersion Include="NuGet.Protocol" Version="7.6.0" />
     <PackageVersion Include="StreamJsonRpc" Version="2.26.2" />
-    <PackageVersion Include="System.Collections.Immutable" Version="10.0.8" />
+    <PackageVersion Include="System.Collections.Immutable" Version="8.0.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.2" />
     <PackageVersion Include="System.IO.Pipes.AccessControl" Version="5.0.0" />
-    <PackageVersion Include="System.Text.Json" Version="10.0.8" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.6" />
     <PackageVersion Include="TraceSource.ActivityTracing" Version="0.1.201-beta" />
     <PackageVersion Include="Xunit.Combinatorial" Version="2.0.24" />
     <PackageVersion Include="xunit.v3.core.mtp-v2" Version="3.2.2" />

--- a/docfx/analyzers/ISB005.md
+++ b/docfx/analyzers/ISB005.md
@@ -1,0 +1,30 @@
+# ISB005 Configure RpcTargetMetadata on creation
+
+When creating a <xref:Microsoft.ServiceHub.Framework.ServiceJsonRpcPolyTypeDescriptor>, call <xref:Microsoft.ServiceHub.Framework.ServiceJsonRpcPolyTypeDescriptor.WithRpcTargetMetadata(System.Collections.Immutable.ImmutableArray{StreamJsonRpc.RpcTargetMetadata})> somewhere in the overall expression that creates the descriptor.
+
+If <xref:Microsoft.ServiceHub.Framework.ServiceJsonRpcPolyTypeDescriptor.RpcTargetMetadata> is left unset and the descriptor is later used on the service side to attach RPC to a target object, activation fails at runtime.
+
+## Examples of patterns that are flagged by this analyzer
+
+The following code generates a diagnostic.
+
+```cs
+static readonly ServiceRpcDescriptor Descriptor = new ServiceJsonRpcPolyTypeDescriptor(
+	new ServiceMoniker("name", new Version(1, 0)),
+	ServiceJsonRpcPolyTypeDescriptor.Formatters.NerdbankMessagePack,
+	ServiceJsonRpcPolyTypeDescriptor.MessageDelimiters.BigEndianInt32LengthHeader,
+	PolyType.SourceGenerator.TypeShapeProvider_Microsoft_ServiceHub_Framework.Default);
+```
+
+## Solution
+
+Call `WithRpcTargetMetadata` somewhere in the overall expression that creates the descriptor.
+
+```cs
+static readonly ServiceRpcDescriptor Descriptor = new ServiceJsonRpcPolyTypeDescriptor(
+	new ServiceMoniker("name", new Version(1, 0)),
+	ServiceJsonRpcPolyTypeDescriptor.Formatters.NerdbankMessagePack,
+	ServiceJsonRpcPolyTypeDescriptor.MessageDelimiters.BigEndianInt32LengthHeader,
+	PolyType.SourceGenerator.TypeShapeProvider_Microsoft_ServiceHub_Framework.Default)
+	.WithRpcTargetMetadata(RpcTargetMetadata.FromShape<IFoo>());
+```

--- a/docfx/analyzers/index.md
+++ b/docfx/analyzers/index.md
@@ -9,5 +9,6 @@ ID | Title
 [ISB002](ISB002.md) | Avoid storing rentals in fields
 [ISB003](ISB003.md) | Exported brokered services are valid
 [ISB004](ISB004.md) | Optional interfaces on exported brokered services are implemented
+[ISB005](ISB005.md) | Configure RpcTargetMetadata immediately
 
 [1]: https://www.nuget.org/packages/microsoft.servicehub.analyzers

--- a/docfx/analyzers/toc.yml
+++ b/docfx/analyzers/toc.yml
@@ -4,3 +4,4 @@ items:
 - href: ISB002.md
 - href: ISB003.md
 - href: ISB004.md
+- href: ISB005.md

--- a/src/Microsoft.ServiceHub.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Microsoft.ServiceHub.Analyzers/AnalyzerReleases.Unshipped.md
@@ -4,3 +4,4 @@
 ### New Rules
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
+ISB005  | Usage    | Warning  | ServiceJsonRpcPolyTypeDescriptor must configure RpcTargetMetadata immediately

--- a/src/Microsoft.ServiceHub.Analyzers/ISB005ServiceJsonRpcPolyTypeDescriptorMustConfigureRpcTargetMetadataAnalyzer.cs
+++ b/src/Microsoft.ServiceHub.Analyzers/ISB005ServiceJsonRpcPolyTypeDescriptorMustConfigureRpcTargetMetadataAnalyzer.cs
@@ -1,0 +1,85 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.CodeAnalysis.Operations;
+
+namespace Microsoft.ServiceHub.Analyzers;
+
+[DiagnosticAnalyzer(LanguageNames.CSharp, LanguageNames.VisualBasic)]
+public class ISB005ServiceJsonRpcPolyTypeDescriptorMustConfigureRpcTargetMetadataAnalyzer : DiagnosticAnalyzer
+{
+	public const string Id = "ISB005";
+
+	public static readonly DiagnosticDescriptor Descriptor = new DiagnosticDescriptor(
+		id: Id,
+		title: new LocalizableResourceString(nameof(Strings.ISB005_Title), Strings.ResourceManager, typeof(Strings)),
+		messageFormat: new LocalizableResourceString(nameof(Strings.ISB005_MessageFormat), Strings.ResourceManager, typeof(Strings)),
+		description: new LocalizableResourceString(nameof(Strings.ISB005_Description), Strings.ResourceManager, typeof(Strings)),
+		helpLinkUri: Utils.GetHelpLink(Id),
+		category: "Usage",
+		defaultSeverity: DiagnosticSeverity.Warning,
+		isEnabledByDefault: true);
+
+	/// <inheritdoc />
+	public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = [Descriptor];
+
+	/// <inheritdoc />
+	public override void Initialize(AnalysisContext context)
+	{
+		if (context is null)
+		{
+			throw new ArgumentNullException(nameof(context));
+		}
+
+		context.EnableConcurrentExecution();
+		context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.Analyze);
+
+		context.RegisterCompilationStartAction(compilationStart =>
+		{
+			INamedTypeSymbol? descriptorType = compilationStart.Compilation.GetTypeByMetadataName(Types.ServiceJsonRpcPolyTypeDescriptor.FullName);
+			if (descriptorType is object)
+			{
+				compilationStart.RegisterOperationAction(Utils.DebuggableWrapper(c => AnalyzeObjectCreation(c, descriptorType)), OperationKind.ObjectCreation);
+			}
+		});
+	}
+
+	private static void AnalyzeObjectCreation(OperationAnalysisContext context, INamedTypeSymbol descriptorType)
+	{
+		var creation = (IObjectCreationOperation)context.Operation;
+		if (!SymbolEqualityComparer.Default.Equals(creation.Type, descriptorType) || IsCopyConstructor(creation, descriptorType) || HasWithRpcTargetMetadataInFluentChain(creation, descriptorType))
+		{
+			return;
+		}
+
+		context.ReportDiagnostic(Diagnostic.Create(Descriptor, creation.Syntax.GetLocation()));
+	}
+
+	private static bool IsCopyConstructor(IObjectCreationOperation creation, INamedTypeSymbol descriptorType)
+		=> creation.Constructor is { Parameters.Length: 1 } constructor && SymbolEqualityComparer.Default.Equals(constructor.Parameters[0].Type, descriptorType);
+
+	private static bool HasWithRpcTargetMetadataInFluentChain(IObjectCreationOperation creation, INamedTypeSymbol descriptorType)
+	{
+		IOperation current = creation;
+		while (true)
+		{
+			while (current.Parent is IConversionOperation parentConversion)
+			{
+				current = parentConversion;
+			}
+
+			if (current.Parent is not IInvocationOperation invocation || invocation.Instance != current)
+			{
+				return false;
+			}
+
+			if (string.Equals(invocation.TargetMethod.Name, Types.ServiceJsonRpcPolyTypeDescriptor.WithRpcTargetMetadata, StringComparison.Ordinal) &&
+				SymbolEqualityComparer.Default.Equals(invocation.TargetMethod.ContainingType, descriptorType))
+			{
+				return true;
+			}
+
+			current = invocation;
+		}
+	}
+}

--- a/src/Microsoft.ServiceHub.Analyzers/README.md
+++ b/src/Microsoft.ServiceHub.Analyzers/README.md
@@ -6,5 +6,8 @@ Analyzer ID | Description
 --|--
 ISB001 | Dispose of proxies
 ISB002 | Avoid storing rentals in fields
+ISB003 | Exported brokered services are valid
+ISB004 | Optional interfaces on exported brokered services are implemented
+ISB005 | Configure RpcTargetMetadata immediately on ServiceJsonRpcPolyTypeDescriptor
 
 Learn more on [our doc site](https://microsoft.github.io/vs-servicehub/analyzers/).

--- a/src/Microsoft.ServiceHub.Analyzers/Strings.resx
+++ b/src/Microsoft.ServiceHub.Analyzers/Strings.resx
@@ -166,4 +166,13 @@
   <data name="ISB004_MessageFormat" xml:space="preserve">
     <value>The brokered service must implement the '{0}' interface or remove it from its list of supported optional interfaces</value>
   </data>
+  <data name="ISB005_Title" xml:space="preserve">
+    <value>Configure RpcTargetMetadata on creation</value>
+  </data>
+  <data name="ISB005_Description" xml:space="preserve">
+    <value>Invoke WithRpcTargetMetadata somewhere in the overall expression that creates a ServiceJsonRpcPolyTypeDescriptor. Otherwise, if the descriptor is used on the service side to attach RPC to a target object, it will fail at runtime because no RpcTargetMetadata was configured.</value>
+  </data>
+  <data name="ISB005_MessageFormat" xml:space="preserve">
+    <value>Invoke WithRpcTargetMetadata in the expression that creates a ServiceJsonRpcPolyTypeDescriptor; otherwise service-side RPC attachment to a target object can fail at runtime because no RpcTargetMetadata was configured</value>
+  </data>
 </root>

--- a/src/Microsoft.ServiceHub.Analyzers/Types.cs
+++ b/src/Microsoft.ServiceHub.Analyzers/Types.cs
@@ -53,4 +53,11 @@ public static class Types
 
 		public const string FullName = $"StreamJsonRpc.{Name}";
 	}
+
+	public static class ServiceJsonRpcPolyTypeDescriptor
+	{
+		public const string FullName = "Microsoft.ServiceHub.Framework.ServiceJsonRpcPolyTypeDescriptor";
+
+		public const string WithRpcTargetMetadata = "WithRpcTargetMetadata";
+	}
 }

--- a/test/Directory.Build.targets
+++ b/test/Directory.Build.targets
@@ -9,6 +9,10 @@
   <ItemGroup>
     <Content Include="xunit.runner.json" CopyToOutputDirectory="PreserveNewest" Condition="Exists('xunit.runner.json')" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageVersion Update="System.Collections.Immutable" Version="10.0.8" />
+    <PackageVersion Update="System.Text.Json" Version="10.0.8" />
+  </ItemGroup>
 
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 </Project>

--- a/test/Microsoft.ServiceHub.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
+++ b/test/Microsoft.ServiceHub.Analyzers.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
@@ -18,8 +18,11 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 			this.SolutionTransforms.Add((solution, projectId) =>
 			{
 				var parseOptions = (CSharpParseOptions?)solution.GetProject(projectId)?.ParseOptions;
-				solution = solution.WithProjectParseOptions(projectId, parseOptions!.WithLanguageVersion(LanguageVersion.CSharp9))
-					.AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(IServiceBroker).Assembly.Location));
+				solution = solution.WithProjectParseOptions(projectId, parseOptions!.WithLanguageVersion(LanguageVersion.CSharp9));
+				if (this.IncludeServiceHubFrameworkReferences)
+				{
+					solution = solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(IServiceBroker).Assembly.Location));
+				}
 
 				return solution;
 			});
@@ -34,7 +37,19 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 			});
 		}
 
+		public bool IncludeServiceHubFrameworkReferences { get; set; } = true;
+
 		internal DiagnosticDescriptor? ExpectedDescriptor { get; set; }
+
+		protected override Task RunImplAsync(CancellationToken cancellationToken)
+		{
+			if (this.IncludeServiceHubFrameworkReferences)
+			{
+				this.TestState.AdditionalReferences.AddRange(ReferencesHelper.GetReferences());
+			}
+
+			return base.RunImplAsync(cancellationToken);
+		}
 
 		protected override DiagnosticDescriptor? GetDefaultDiagnostic(DiagnosticAnalyzer[] analyzers)
 		{

--- a/test/Microsoft.ServiceHub.Analyzers.Tests/Helpers/VisualBasicCodeFixVerifier`2+Test.cs
+++ b/test/Microsoft.ServiceHub.Analyzers.Tests/Helpers/VisualBasicCodeFixVerifier`2+Test.cs
@@ -21,8 +21,11 @@ public static partial class VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix>
 			this.SolutionTransforms.Add((solution, projectId) =>
 			{
 				var parseOptions = (VisualBasicParseOptions?)solution.GetProject(projectId)?.ParseOptions;
-				solution = solution.WithProjectParseOptions(projectId, parseOptions!.WithLanguageVersion(LanguageVersion.Latest))
-					.AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(IServiceBroker).Assembly.Location));
+				solution = solution.WithProjectParseOptions(projectId, parseOptions!.WithLanguageVersion(LanguageVersion.Latest));
+				if (this.IncludeServiceHubFrameworkReferences)
+				{
+					solution = solution.AddMetadataReference(projectId, MetadataReference.CreateFromFile(typeof(IServiceBroker).Assembly.Location));
+				}
 
 				return solution;
 			});
@@ -37,7 +40,19 @@ public static partial class VisualBasicCodeFixVerifier<TAnalyzer, TCodeFix>
 			});
 		}
 
+		public bool IncludeServiceHubFrameworkReferences { get; set; } = true;
+
 		internal DiagnosticDescriptor? ExpectedDescriptor { get; set; }
+
+		protected override Task RunImplAsync(CancellationToken cancellationToken)
+		{
+			if (this.IncludeServiceHubFrameworkReferences)
+			{
+				this.TestState.AdditionalReferences.AddRange(ReferencesHelper.GetReferences());
+			}
+
+			return base.RunImplAsync(cancellationToken);
+		}
 
 		protected override DiagnosticDescriptor? GetDefaultDiagnostic(DiagnosticAnalyzer[] analyzers)
 		{

--- a/test/Microsoft.ServiceHub.Analyzers.Tests/ISB005ServiceJsonRpcPolyTypeDescriptorMustConfigureRpcTargetMetadataAnalyzerTests.cs
+++ b/test/Microsoft.ServiceHub.Analyzers.Tests/ISB005ServiceJsonRpcPolyTypeDescriptorMustConfigureRpcTargetMetadataAnalyzerTests.cs
@@ -1,0 +1,121 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using VerifyCS = CSharpCodeFixVerifier<Microsoft.ServiceHub.Analyzers.ISB005ServiceJsonRpcPolyTypeDescriptorMustConfigureRpcTargetMetadataAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+using VerifyVB = VisualBasicCodeFixVerifier<Microsoft.ServiceHub.Analyzers.ISB005ServiceJsonRpcPolyTypeDescriptorMustConfigureRpcTargetMetadataAnalyzer, Microsoft.CodeAnalysis.Testing.EmptyCodeFixProvider>;
+
+public class ISB005ServiceJsonRpcPolyTypeDescriptorMustConfigureRpcTargetMetadataAnalyzerTests
+{
+	private const string CSPreamble = """
+		using System;
+		using Microsoft.ServiceHub.Framework;
+
+		""";
+
+	private const string VBPreamble = """
+		Imports System
+		Imports Microsoft.ServiceHub.Framework
+
+		""";
+
+	[Fact]
+	public async Task Valid_ImmediateInvocation_CS()
+	{
+		string test = CSPreamble + """
+			class Test
+			{
+				private static readonly ServiceRpcDescriptor Descriptor = new ServiceJsonRpcPolyTypeDescriptor(
+					new ServiceMoniker("MyService", new Version(1, 0)),
+					ServiceJsonRpcPolyTypeDescriptor.Formatters.NerdbankMessagePack,
+					ServiceJsonRpcPolyTypeDescriptor.MessageDelimiters.BigEndianInt32LengthHeader,
+					null!)
+					.WithRpcTargetMetadata(default)
+					.WithExceptionStrategy(default);
+			}
+			""";
+		await VerifyCS.VerifyAnalyzerAsync(test);
+	}
+
+	[Fact]
+	public async Task Invalid_MissingImmediateInvocation_CS()
+	{
+		string test = CSPreamble + """
+			class Test
+			{
+				private static readonly ServiceRpcDescriptor Descriptor = [|new ServiceJsonRpcPolyTypeDescriptor(
+					new ServiceMoniker("MyService", new Version(1, 0)),
+					ServiceJsonRpcPolyTypeDescriptor.Formatters.NerdbankMessagePack,
+					ServiceJsonRpcPolyTypeDescriptor.MessageDelimiters.BigEndianInt32LengthHeader,
+					null!)|];
+			}
+			""";
+		await VerifyCS.VerifyAnalyzerAsync(test);
+	}
+
+	[Fact]
+	public async Task Valid_MetadataConfiguredLater_CS()
+	{
+		string test = CSPreamble + """
+			class Test
+			{
+				private static readonly ServiceRpcDescriptor Descriptor = new ServiceJsonRpcPolyTypeDescriptor(
+					new ServiceMoniker("MyService", new Version(1, 0)),
+					ServiceJsonRpcPolyTypeDescriptor.Formatters.NerdbankMessagePack,
+					ServiceJsonRpcPolyTypeDescriptor.MessageDelimiters.BigEndianInt32LengthHeader,
+					null!)
+					.WithExceptionStrategy(default)
+					.WithRpcTargetMetadata(default);
+			}
+			""";
+		await VerifyCS.VerifyAnalyzerAsync(test);
+	}
+
+	[Fact]
+	public async Task Valid_ImmediateInvocation_VB()
+	{
+		string test = VBPreamble + """
+			Class Test
+				Private Shared ReadOnly Descriptor As ServiceRpcDescriptor = New ServiceJsonRpcPolyTypeDescriptor(
+					New ServiceMoniker("MyService", New Version(1, 0)),
+					ServiceJsonRpcPolyTypeDescriptor.Formatters.NerdbankMessagePack,
+					ServiceJsonRpcPolyTypeDescriptor.MessageDelimiters.BigEndianInt32LengthHeader,
+					Nothing).
+					WithRpcTargetMetadata(Nothing).
+					WithExceptionStrategy(Nothing)
+			End Class
+			""";
+		await VerifyVB.VerifyAnalyzerAsync(test);
+	}
+
+	[Fact]
+	public async Task Invalid_MissingImmediateInvocation_VB()
+	{
+		string test = VBPreamble + """
+			Class Test
+				Private Shared ReadOnly Descriptor As ServiceRpcDescriptor = [|New ServiceJsonRpcPolyTypeDescriptor(
+					New ServiceMoniker("MyService", New Version(1, 0)),
+					ServiceJsonRpcPolyTypeDescriptor.Formatters.NerdbankMessagePack,
+					ServiceJsonRpcPolyTypeDescriptor.MessageDelimiters.BigEndianInt32LengthHeader,
+					Nothing)|]
+			End Class
+			""";
+		await VerifyVB.VerifyAnalyzerAsync(test);
+	}
+
+	[Fact]
+	public async Task Valid_MetadataConfiguredLater_VB()
+	{
+		string test = VBPreamble + """
+			Class Test
+				Private Shared ReadOnly Descriptor As ServiceRpcDescriptor = New ServiceJsonRpcPolyTypeDescriptor(
+					New ServiceMoniker("MyService", New Version(1, 0)),
+					ServiceJsonRpcPolyTypeDescriptor.Formatters.NerdbankMessagePack,
+					ServiceJsonRpcPolyTypeDescriptor.MessageDelimiters.BigEndianInt32LengthHeader,
+					Nothing).
+					WithExceptionStrategy(Nothing).
+					WithRpcTargetMetadata(Nothing)
+			End Class
+			""";
+		await VerifyVB.VerifyAnalyzerAsync(test);
+	}
+}

--- a/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcPolyTypeDescriptorTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcPolyTypeDescriptorTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#pragma warning disable ISB005 // Call WithRpcTargetMetadata on every descriptor.
+
 using System.Diagnostics;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.VisualStudio.Threading;

--- a/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcPolyTypeDescriptor_ProxyTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcPolyTypeDescriptor_ProxyTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#pragma warning disable ISB005 // Call WithRpcTargetMetadata on every descriptor.
+
 using System.Collections.Immutable;
 using Microsoft.ServiceHub.Framework;
 using StreamJsonRpc;

--- a/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcPolyTypeDescriptor_RpcProxyTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/ServiceJsonRpcPolyTypeDescriptor_RpcProxyTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#pragma warning disable ISB005 // Call WithRpcTargetMetadata on every descriptor.
+
 using System.Collections.Immutable;
 using System.Diagnostics;
 using Microsoft.ServiceHub.Framework;

--- a/test/Microsoft.ServiceHub.Framework.Tests/SourceGeneratedLocalProxyTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/SourceGeneratedLocalProxyTests.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
+#pragma warning disable ISB005 // Call WithRpcTargetMetadata on every descriptor.
+
 using Microsoft;
 using Microsoft.ServiceHub.Framework;
 using PolyType;


### PR DESCRIPTION
Creating one of the new `ServiceJsonRpcPolyTypeDescriptor` objects can easily be done in a buggy way -- without a follow-up call to `WithRpcTargetMetadata`. This change adds an analyzer to report a warning when people leave that out.

II also change the ref assembly versions so that the analyzers work on the .NET 8 SDK.