### PR TITLE
Fix `ServiceJsonRpcPolyTypeDescriptor` handling around multiplexing stream

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.ProfferedServiceFactory.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.ProfferedServiceFactory.cs
@@ -97,7 +97,7 @@ public abstract partial class GlobalBrokeredServiceContainer
 			(IDuplexPipe, IDuplexPipe) pipePair = FullDuplexStream.CreatePipePair();
 
 			// We encourage users to migrate to descriptors configured with ServiceJsonRpcDescriptor.WithMultiplexingStream(MultiplexingStream.Options).
-			ServiceRpcDescriptor descriptor = this.Descriptor is not ServiceJsonRpcDescriptor { MultiplexingStreamOptions: not null }
+			ServiceRpcDescriptor descriptor = this.Descriptor is not (ServiceJsonRpcDescriptor { MultiplexingStreamOptions: not null } or ServiceJsonRpcPolyTypeDescriptor { MultiplexingStreamOptions: not null })
 #pragma warning disable CS0618 // Type or member is obsolete, only for backward compatibility.
 				 ? this.Descriptor.WithMultiplexingStream(options.MultiplexingStream)
 #pragma warning restore CS0618 // Type or member is obsolete

--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.ProfferedViewIntrinsicService.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.ProfferedViewIntrinsicService.cs
@@ -67,14 +67,15 @@ public abstract partial class GlobalBrokeredServiceContainer
 		{
 			(IDuplexPipe, IDuplexPipe) pipePair = FullDuplexStream.CreatePipePair();
 
-			ServiceRpcDescriptor descriptor = this.Descriptor is ServiceJsonRpcDescriptor serviceJsonRpcDescriptor
-				 ? serviceJsonRpcDescriptor.MultiplexingStreamOptions is object ? this.Descriptor :
+			ServiceRpcDescriptor descriptor = this.Descriptor;
 
-					// We encourage users to migrate to descriptors configured with ServiceJsonRpcDescriptor.WithMultiplexingStream(MultiplexingStream.Options).
+			// We encourage users to migrate to descriptors configured with ServiceJsonRpcDescriptor.WithMultiplexingStream(MultiplexingStream.Options).
+			if (descriptor is not (ServiceJsonRpcDescriptor { MultiplexingStreamOptions: not null } or ServiceJsonRpcPolyTypeDescriptor { MultiplexingStreamOptions: not null }))
+			{
 #pragma warning disable CS0618 // Type or member is obsolete, only for backward compatibility.
-					this.Descriptor.WithMultiplexingStream(options.MultiplexingStream)
+				descriptor = descriptor.WithMultiplexingStream(options.MultiplexingStream);
 #pragma warning restore CS0618 // Type or member is obsolete
-				 : this.Descriptor;
+			}
 
 			IServiceBroker serviceBroker = this.Container.GetSecureServiceBroker(options);
 			descriptor = await this.Container.ApplyDescriptorSettingsInternalAsync(descriptor, serviceBroker, options, clientRole: false, cancellationToken).ConfigureAwait(false);

--- a/src/Microsoft.ServiceHub.Framework/Container/ServiceBrokerOfExportedServices.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/ServiceBrokerOfExportedServices.cs
@@ -5,7 +5,6 @@ using System.Collections.Immutable;
 using System.Composition;
 using System.Diagnostics;
 using System.IO.Pipelines;
-using System.Linq;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.ServiceHub.Framework.Services;
 using Microsoft.VisualStudio.Threading;
@@ -129,11 +128,11 @@ public abstract class ServiceBrokerOfExportedServices : IServiceBroker
 
 				using (options.ApplyCultureToCurrentContext())
 				{
-					if (descriptor is ServiceJsonRpcDescriptor { MultiplexingStreamOptions: null } oldJsonRpcDescriptor)
+					if (descriptor is not (ServiceJsonRpcDescriptor { MultiplexingStreamOptions: not null } or ServiceJsonRpcPolyTypeDescriptor { MultiplexingStreamOptions: not null }))
 					{
 						// We encourage users to migrate to descriptors configured with ServiceJsonRpcDescriptor.WithMultiplexingStream(MultiplexingStream.Options).
 #pragma warning disable CS0618 // Type or member is obsolete, only for backward compatibility.
-						descriptor = oldJsonRpcDescriptor.WithMultiplexingStream(options.MultiplexingStream);
+						descriptor = descriptor.WithMultiplexingStream(options.MultiplexingStream);
 #pragma warning restore CS0618 // Type or member is obsolete
 					}
 

--- a/src/Microsoft.ServiceHub.Framework/RemoteServiceBroker.cs
+++ b/src/Microsoft.ServiceHub.Framework/RemoteServiceBroker.cs
@@ -515,12 +515,12 @@ public class RemoteServiceBroker : IServiceBroker, IDisposable, System.IAsyncDis
 
 			if (this.multiplexingStream is object)
 			{
-				// Stream can be setup only for ServiceJsonRpcDescriptor.
-				// We encourage users to migrate to descriptors configured with ServiceJsonRpcDescriptor.WithMultiplexingStream(MultiplexingStream.Options).
-				if (serviceDescriptor is ServiceJsonRpcDescriptor serviceJsonRpcDescriptor && serviceJsonRpcDescriptor.MultiplexingStreamOptions is null)
+				// Stream can be setup only for ServiceJsonRpcDescriptor and ServiceJsonRpcPolyTypeDescriptor.
+				// We encourage users to migrate to descriptors configured with WithMultiplexingStream(MultiplexingStream.Options).
+				if (serviceDescriptor is not (ServiceJsonRpcDescriptor { MultiplexingStreamOptions: not null } or ServiceJsonRpcPolyTypeDescriptor { MultiplexingStreamOptions: not null }))
 				{
 #pragma warning disable CS0618 // Type or member is obsolete, only for backward compatibility.
-					serviceDescriptor = serviceJsonRpcDescriptor.WithMultiplexingStream(this.multiplexingStream);
+					serviceDescriptor = serviceDescriptor.WithMultiplexingStream(this.multiplexingStream);
 #pragma warning restore CS0618 // Type or member is obsolete
 				}
 			}

--- a/test/Microsoft.ServiceHub.Framework.Tests/Container/BrokeredServiceContainerTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/Container/BrokeredServiceContainerTests.cs
@@ -1,19 +1,22 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using System.Collections.Immutable;
 using System.Diagnostics;
-using Microsoft;
+using System.IO.Pipelines;
 using Microsoft.ServiceHub.Framework;
 using Microsoft.ServiceHub.Framework.Testing;
 using Microsoft.VisualStudio.Shell.ServiceBroker;
 using Microsoft.VisualStudio.Utilities.ServiceBroker;
 using Nerdbank.Streams;
-using Xunit;
+using StreamJsonRpc;
 
 public class BrokeredServiceContainerTests : TestBase
 {
 	private static readonly ServiceRpcDescriptor Descriptor = new ServiceJsonRpcDescriptor(new ServiceMoniker("TestService"), ServiceJsonRpcDescriptor.Formatters.MessagePack, ServiceJsonRpcDescriptor.MessageDelimiters.BigEndianInt32LengthHeader);
+	private static readonly ServiceRpcDescriptor PolyTypeDescriptorWithMultiplexing = new ServiceJsonRpcPolyTypeDescriptor(new ServiceMoniker("TestPolyTypeService"), ServiceJsonRpcPolyTypeDescriptor.Formatters.NerdbankMessagePack, ServiceJsonRpcPolyTypeDescriptor.MessageDelimiters.BigEndianInt32LengthHeader, PolyType.SourceGenerator.TypeShapeProvider_Microsoft_ServiceHub_Framework_Tests.Default)
+		.WithRpcTargetMetadata(RpcTargetMetadata.FromShape<ITestRpcContract>())
+		.WithMultiplexingStream(new() { ProtocolMajorVersion = 3 });
+
 #pragma warning disable SA1310 // Field names should not contain underscore
 	private static readonly ServiceRpcDescriptor Descriptor1_0 = new ServiceJsonRpcDescriptor(new ServiceMoniker("TestService", new(1, 0)), ServiceJsonRpcDescriptor.Formatters.MessagePack, ServiceJsonRpcDescriptor.MessageDelimiters.BigEndianInt32LengthHeader);
 	private static readonly ServiceRpcDescriptor Descriptor1_1 = new ServiceJsonRpcDescriptor(new ServiceMoniker("TestService", new(1, 1)), ServiceJsonRpcDescriptor.Formatters.MessagePack, ServiceJsonRpcDescriptor.MessageDelimiters.BigEndianInt32LengthHeader);
@@ -242,6 +245,24 @@ public class BrokeredServiceContainerTests : TestBase
 		this.ProfferUnversionedService();
 		IMockService? proxy = await this.serviceBroker.GetProxyAsync<IMockService>(Descriptor, this.TimeoutToken);
 		Assert.NotNull(proxy);
+	}
+
+	[Fact]
+	public async Task ProfferedPolyTypeDescriptorPreservesMultiplexingOptions()
+	{
+		this.container.Proffer(PolyTypeDescriptorWithMultiplexing, (mk, options, sb, ct) => new(new TestRpcService()));
+
+		IDuplexPipe? pipe = await this.serviceBroker.GetPipeAsync(PolyTypeDescriptorWithMultiplexing.Moniker, this.TimeoutToken);
+		Assert.NotNull(pipe);
+
+		ITestRpcContract proxy = PolyTypeDescriptorWithMultiplexing.ConstructRpc<ITestRpcContract>(pipe);
+		using (proxy as IDisposable)
+		{
+			MemoryStream stream = new([1, 2, 3]);
+			byte[] result = await proxy.ReadStreamAsync(stream, this.TimeoutToken);
+
+			Assert.Equal(stream.ToArray(), result);
+		}
 	}
 
 	private void ProfferUnversionedService()


### PR DESCRIPTION
We had special-case code for `ServiceJsonRpcDescriptor`, but that code needs to accommodate the newer `ServiceJsonRpcPolyTypeDescriptor` as well.
