### PR TITLE
Respect queue-time variables even when empty in _define.ps1

### DIFF
--- a/tools/variables/_define.ps1
+++ b/tools/variables/_define.ps1
@@ -14,8 +14,17 @@ param (
 (& "$PSScriptRoot\_all.ps1").GetEnumerator() |% {
     # Always use ALL CAPS for env var names since Azure Pipelines converts variable names to all caps and on non-Windows OS, env vars are case sensitive.
     $keyCaps = $_.Key.ToUpper()
-    if ((Test-Path "env:$keyCaps") -and (Get-Content "env:$keyCaps")) {
-        Write-Host "Skipping setting $keyCaps because variable is already set to '$(Get-Content env:$keyCaps)'." -ForegroundColor Cyan
+    $existingValue = if (Test-Path "env:$keyCaps") { Get-Content "env:$keyCaps" } else { $null }
+    # On Azure Pipelines, treat any pre-set env var slot as authoritative -- even when empty -- because
+    # queue-time variables are exposed as env vars and are read-only on the run. Emitting task.setvariable
+    # against an empty queue-time variable used to be silently overwritten; under the readonly-variables
+    # rollout it now hard-fails with "Overwriting readonly variable".
+    # Off Azure Pipelines (local, GitHub Actions, etc.), keep requiring a non-empty value: on Linux,
+    # env vars can be inherited as empty for unrelated reasons and shouldn't suppress the computed value.
+    $isAlreadySet = if ($env:TF_BUILD) { $null -ne $existingValue } else { [bool]$existingValue }
+    if ($isAlreadySet) {
+        $displayValue = if ($existingValue) { "'$existingValue'" } else { "(empty)" }
+        Write-Host "Skipping setting $keyCaps because variable is already set to $displayValue." -ForegroundColor Cyan
     } else {
         Write-Host "$keyCaps=$($_.Value)" -ForegroundColor Yellow
         if ($env:TF_BUILD) {


### PR DESCRIPTION
An attempt to fix insertion build issue https://devdiv.visualstudio.com/DevDiv/DevDiv%20Team/_build/results?buildId=14465052&view=results

When a build is queued with a variable (e.g. InsertTargetBranch) supplied at queue time, Azure Pipelines marks it read-only. The previous guard required the env var to be both present AND non-empty before skipping, so an empty queue-time value fell through to `##vso[task.setvariable]`, which Azure Pipelines now hard-fails with `Overwriting readonly variable`.

Change the guard to test for env-var slot presence only. A queue-time variable is respected verbatim, whether the user supplied a value or left it blank; the fall-back default from _all.ps1 still applies when nothing was supplied at queue time.

Repros and was fixed verified locally against the three cases:
  1. empty queue-time variable  - script skips, no setvariable emitted
  2. non-empty queue-time value - script skips, override respected
  3. no queue-time variable     - default propagates as before