### PR TITLE
Trace an activity start/stop pair for RequestServiceChannelAsync calls

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.View.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/GlobalBrokeredServiceContainer.View.cs
@@ -321,6 +321,8 @@ public abstract partial class GlobalBrokeredServiceContainer
 			Requires.NotNull(serviceMoniker, nameof(serviceMoniker));
 			serviceActivationOptions = this.ApplyOptionsFilter(serviceActivationOptions);
 
+			using StartActivityExtension.TraceActivity activity = this.container.traceSource.StartActivity("Requesting service channel to \"{0}\"", serviceMoniker);
+
 			try
 			{
 				(IProffered? proffered, MissingBrokeredServiceErrorCode errorCode) = await this.TryGetProfferingSourceAsync(serviceMoniker, isRemoteRequest: true, cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Previous to this, `GetPipeAsync` and `GetProxyAsync` were already tracing activities. This one was left out.
