### PR TITLE
Don't report caller-token cancellation as ServiceActivationFailedExce…

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/Container/ServiceBrokerOfExportedServices.cs
+++ b/src/Microsoft.ServiceHub.Framework/Container/ServiceBrokerOfExportedServices.cs
@@ -176,8 +176,11 @@ public abstract class ServiceBrokerOfExportedServices : IServiceBroker
 				throw;
 			}
 		}
-		catch (Exception ex)
+		catch (Exception ex) when (!(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
 		{
+			// A cancellation requested via the caller's own token is an expected outcome, not an activation
+			// failure. Let it propagate as OperationCanceledException -- matching GlobalBrokeredServiceContainer.View.GetProxyAsync --
+			// so callers that observe their own cancellation don't see (and report) a ServiceActivationFailedException.
 			throw new ServiceActivationFailedException(serviceMoniker, ex);
 		}
 	}
@@ -240,8 +243,11 @@ public abstract class ServiceBrokerOfExportedServices : IServiceBroker
 				throw;
 			}
 		}
-		catch (Exception ex)
+		catch (Exception ex) when (!(ex is OperationCanceledException && cancellationToken.IsCancellationRequested))
 		{
+			// A cancellation requested via the caller's own token is an expected outcome, not an activation
+			// failure. Let it propagate as OperationCanceledException -- matching GlobalBrokeredServiceContainer.View.GetProxyAsync --
+			// so callers that observe their own cancellation don't see (and report) a ServiceActivationFailedException.
 			throw new ServiceActivationFailedException(serviceDescriptor.Moniker, ex);
 		}
 	}

--- a/test/Microsoft.ServiceHub.Framework.Tests/Container/ServiceBrokerOfExportedServicesTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/Container/ServiceBrokerOfExportedServicesTests.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+using Microsoft.ServiceHub.Framework;
+using Microsoft.VisualStudio.Shell.ServiceBroker;
+using Xunit;
+
+/// <summary>
+/// Tests for <see cref="ServiceBrokerOfExportedServices"/>.
+/// </summary>
+public class ServiceBrokerOfExportedServicesTests : TestBase
+{
+	private static readonly ServiceRpcDescriptor Descriptor = new ServiceJsonRpcDescriptor(
+		new ServiceMoniker("TestService"),
+		ServiceJsonRpcDescriptor.Formatters.MessagePack,
+		ServiceJsonRpcDescriptor.MessageDelimiters.BigEndianInt32LengthHeader);
+
+	public ServiceBrokerOfExportedServicesTests(ITestOutputHelper logger)
+		: base(logger)
+	{
+	}
+
+	private interface IMockService
+	{
+	}
+
+	/// <summary>
+	/// Verifies that a cancellation requested via the caller's own token surfaces as
+	/// <see cref="OperationCanceledException"/> rather than being wrapped in a
+	/// <see cref="ServiceActivationFailedException"/>. Callers (e.g. Roslyn's Edit-and-Continue
+	/// brokered service proxy) suppress their own cancellations, so a wrapped activation failure
+	/// would be misreported as a non-fatal error.
+	/// </summary>
+	[Fact]
+	public async Task GetProxyAsync_CallerCanceledToken_ThrowsOperationCanceled()
+	{
+		IServiceBroker broker = new MockServiceBrokerOfExportedServices();
+		using CancellationTokenSource cts = new();
+		cts.Cancel();
+
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(
+			async () => await broker.GetProxyAsync<IMockService>(Descriptor, cts.Token));
+	}
+
+	/// <inheritdoc cref="GetProxyAsync_CallerCanceledToken_ThrowsOperationCanceled"/>
+	[Fact]
+	public async Task GetPipeAsync_CallerCanceledToken_ThrowsOperationCanceled()
+	{
+		IServiceBroker broker = new MockServiceBrokerOfExportedServices();
+		using CancellationTokenSource cts = new();
+		cts.Cancel();
+
+		await Assert.ThrowsAnyAsync<OperationCanceledException>(
+			async () => await broker.GetPipeAsync(Descriptor.Moniker, cts.Token));
+	}
+}


### PR DESCRIPTION
Addresses https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3017267

When a brokered service is acquired via the MEF-exported-services broker (ServiceBrokerOfExportedServices.GetPipeAsync / GetProxyAsync) and the caller cancels via its own token, the OperationCanceledException was caught by the outer 'catch (Exception ex)' and rewrapped as ServiceActivationFailedException. Callers that suppress their own cancellation (e.g. Roslyn's Edit-and-Continue brokered service proxy, via FatalError.ReportAndCatchUnlessCanceled) cannot see that the wrapped exception is a cancellation, so they report a non-fatal Watson for what is an expected, benign cancellation.

GlobalBrokeredServiceContainer.View.GetProxyAsync already guards against this with an exception filter. Apply the same guard to both overloads here so a caller-token cancellation propagates as OperationCanceledException instead of an activation failure. This surfaced as a PerfDDRITs VS_FaultEvents_Total regression in the Debugging scenario after an insertion changed cancellation timing on this path.

Adds tests covering both overloads.