### PR TITLE
Bump MessagePack (for tests) to 2.5.302

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,6 +13,7 @@
     <VSThreadingVersion>18.7.16</VSThreadingVersion>
   </PropertyGroup>
   <ItemGroup>
+    <PackageVersion Include="MessagePack" Version="2.5.302" />
     <PackageVersion Include="Microsoft.IO.Redist" Version="6.1.0" />
     <PackageVersion Include="microsoft.testing.platform.msbuild" Version="$(MicrosoftTestingPlatformVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(CodeAnalysisVersion)" />


### PR DESCRIPTION
This resolves a Component Governance alert.
