### PR TITLE
Trace disposed remote service requests

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/RemoteServiceBroker.cs
+++ b/src/Microsoft.ServiceHub.Framework/RemoteServiceBroker.cs
@@ -462,6 +462,11 @@ public class RemoteServiceBroker : IServiceBroker, IDisposable, System.IAsyncDis
 		{
 			// If we've lost our connection and/or been disposed, be polite during a delay between that event and when folks stop using our service broker
 			// by simply returning null for the service. When aggregated with other service brokers, this provides the graceful fallback path that folks want.
+			if (this.TraceSource.Switch.ShouldTrace(TraceEventType.Error))
+			{
+				this.TraceSource.TraceEvent(TraceEventType.Error, (int)TraceEvents.ServiceRequestFailure, "Remote connection lost. Unable to complete request for service.");
+			}
+
 			return null;
 		}
 


### PR DESCRIPTION
Disposed remote service brokers intentionally return `null` so aggregated brokers can use their graceful fallback path. This adds the existing `ServiceRequestFailure` error trace to the equivalent `GetProxyAsync` path, making those declined requests visible without changing behavior.