### PR TITLE
Fix brace-expansion v2 override

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,6 +9,14 @@
 		{
 			"matchFileNames": ["Directory.Packages.Analyzers.props"],
 			"enabled": false
+		},
+		{
+			"description": "Keep pnpm major-version overrides within their selected major.",
+			"matchManagers": ["npm"],
+			"matchFileNames": ["src/servicebroker-npm/pnpm-workspace.yaml"],
+			"matchPackageNames": ["/@\\d+$/"],
+			"matchUpdateTypes": ["major"],
+			"enabled": false
 		}
 	],
 	"customManagers": [

--- a/src/servicebroker-npm/pnpm-lock.yaml
+++ b/src/servicebroker-npm/pnpm-lock.yaml
@@ -36,7 +36,7 @@ overrides:
   ajv: 8.20.0
   baseline-browser-mapping: 2.11.1
   brace-expansion@1: 1.1.16
-  brace-expansion@2: 5.0.7
+  brace-expansion@2: 2.1.2
   brace-expansion@5: 5.0.8
   browserslist: 4.28.7
   caniuse-lite: 1.0.30001806
@@ -854,9 +854,8 @@ packages:
   brace-expansion@1.1.16:
     resolution: {integrity: sha1-cj06MMBVjCJavJ/Eeac+FOJsPC8=}
 
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha1-Gw5GlltHna1lr3N7SgJ5CgVJgzc=}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@2.1.2:
+    resolution: {integrity: sha1-C7oicf631Fiw0xrRNiWqpHVEMeI=}
 
   brace-expansion@5.0.8:
     resolution: {integrity: sha1-E1rQ2NgI6xjrXg7Joh86C5LvGM8=}
@@ -3018,9 +3017,9 @@ snapshots:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.7:
+  brace-expansion@2.1.2:
     dependencies:
-      balanced-match: 4.0.4
+      balanced-match: 1.0.2
 
   brace-expansion@5.0.8:
     dependencies:
@@ -3952,7 +3951,7 @@ snapshots:
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 2.1.2
 
   minimist@1.2.8: {}
 

--- a/src/servicebroker-npm/pnpm-workspace.yaml
+++ b/src/servicebroker-npm/pnpm-workspace.yaml
@@ -41,7 +41,7 @@ overrides:
   ajv: 8.20.0
   baseline-browser-mapping: 2.11.1
   'brace-expansion@1': 1.1.16
-  'brace-expansion@2': 5.0.7
+  'brace-expansion@2': 2.1.2
   'brace-expansion@5': 5.0.8
   browserslist: 4.28.7
   caniuse-lite: 1.0.30001806


### PR DESCRIPTION
## Summary
- restore the `brace-expansion@2` pnpm override to the compatible, patched `2.1.2` release
- preserve the resolved v5.0.8 dependency used by the v5-specific override
- prevent Renovate from proposing major updates for major-version-qualified pnpm overrides while continuing to allow compatible updates

## Validation
- `npm exec --yes --package=pnpm@11.17.0 -- pnpm install --lockfile-only --frozen-lockfile`
- `npm exec --yes --package=pnpm@11.17.0 -- pnpm audit --prod --json`
- `npm exec --yes --package=renovate@latest -- renovate-config-validator .github/renovate.json`
- `npm exec --yes --package=pnpm@11.17.0 -- pnpm test`