### PR TITLE
Fail brokered service pipe connects when the server is gone

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/AsyncNamedPipeClientStream.cs
+++ b/src/Microsoft.ServiceHub.Framework/AsyncNamedPipeClientStream.cs
@@ -80,27 +80,44 @@ internal class AsyncNamedPipeClientStream : PipeStream
 	/// Connects pipe client to server.
 	/// </summary>
 	/// <param name="maxRetries">Maximum number of retries.</param>
+	/// <param name="maxRetriesWhenPipeIsMissing">Maximum number of retries to take while the pipe does not exist. This caps <paramref name="maxRetries"/> for that particular failure.</param>
 	/// <param name="retryDelayMs">Milliseconds delay between retries.</param>
 	/// <param name="cancellationToken">Cancellation token.</param>
 	/// <returns>A task representing the establishment of the client connection.</returns>
+	/// <exception cref="FileNotFoundException">Thrown if the pipe does not exist after <paramref name="maxRetriesWhenPipeIsMissing"/> retries.</exception>
 	/// <exception cref="TimeoutException">Thrown if no connection can be established.</exception>
 	internal async Task ConnectAsync(
 		int maxRetries,
+		int maxRetriesWhenPipeIsMissing,
 		int retryDelayMs,
 		CancellationToken cancellationToken)
 	{
 		var errorCodeMap = new Dictionary<int, int>();
 		int retries = 0;
+		int retriesWhilePipeMissing = 0;
 		while (!cancellationToken.IsCancellationRequested)
 		{
-			if (retries > maxRetries || this.TryConnect())
+			if (retries > maxRetries || this.TryConnect(out int errorCode))
 			{
 				break;
 			}
 
 			retries++;
-			var errorCode = Marshal.GetLastWin32Error();
 			errorCodeMap[errorCode] = errorCodeMap.ContainsKey(errorCode) ? errorCodeMap[errorCode] + 1 : 1;
+
+			if (maxRetriesWhenPipeIsMissing < int.MaxValue)
+			{
+				// Only consecutive misses indicate a server that is gone. A server that is recreating its pipe
+				// produces isolated misses interleaved with other errors, so any other error resets the count.
+				if (errorCode is not ((int)WIN32_ERROR.ERROR_FILE_NOT_FOUND or (int)WIN32_ERROR.ERROR_PATH_NOT_FOUND))
+				{
+					retriesWhilePipeMissing = 0;
+				}
+				else if (retriesWhilePipeMissing++ >= maxRetriesWhenPipeIsMissing)
+				{
+					throw new FileNotFoundException($"The pipe '{this.pipePath}' does not exist.", this.pipePath);
+				}
+			}
 
 			await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
 		}
@@ -130,7 +147,7 @@ internal class AsyncNamedPipeClientStream : PipeStream
 		return access;
 	}
 
-	private bool TryConnect()
+	private bool TryConnect(out int errorCode)
 	{
 		SafePipeHandle handle = CreateNamedPipeClient(
 			this.pipePath,
@@ -143,9 +160,13 @@ internal class AsyncNamedPipeClientStream : PipeStream
 
 		if (handle.IsInvalid)
 		{
+			// Read the error before disposing the handle, since disposal overwrites it.
+			errorCode = Marshal.GetLastWin32Error();
 			handle.Dispose();
 			return false;
 		}
+
+		errorCode = 0;
 
 		// Success!
 		this.InitializeHandle(handle, false, true);

--- a/src/Microsoft.ServiceHub.Framework/RemoteServiceBroker.cs
+++ b/src/Microsoft.ServiceHub.Framework/RemoteServiceBroker.cs
@@ -259,7 +259,7 @@ public class RemoteServiceBroker : IServiceBroker, IDisposable, System.IAsyncDis
 	{
 		Requires.NotNullOrEmpty(pipeName, nameof(pipeName));
 
-		IDuplexPipe pipe = await ConnectToPipeAsync(pipeName, cancellationToken).ConfigureAwait(false);
+		IDuplexPipe pipe = await ConnectToPipeAsync(pipeName, serverAlreadyListening: false, cancellationToken).ConfigureAwait(false);
 		IRemoteServiceBroker serviceBroker = FrameworkServices.RemoteServiceBroker
 			.WithTraceSource(traceSource)
 			.ConstructRpc<IRemoteServiceBroker>(pipe);
@@ -407,7 +407,7 @@ public class RemoteServiceBroker : IServiceBroker, IDisposable, System.IAsyncDis
 					this.TraceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.RequestedServiceUnavailable, "Service \"{0}\" available over named pipe \"{1}\".", serviceMoniker, remoteConnectionInfo.PipeName);
 				}
 
-				return await ConnectToPipeAsync(remoteConnectionInfo.PipeName!, cancellationToken).ConfigureAwait(false);
+				return await ConnectToPipeAsync(remoteConnectionInfo.PipeName!, serverAlreadyListening: true, cancellationToken).ConfigureAwait(false);
 			}
 			else
 			{
@@ -496,7 +496,7 @@ public class RemoteServiceBroker : IServiceBroker, IDisposable, System.IAsyncDis
 					this.TraceSource.TraceEvent(TraceEventType.Information, (int)TraceEvents.RequestedServiceUnavailable, "Service \"{0}\" available over named pipe \"{1}\".", serviceDescriptor.Moniker, remoteConnectionInfo.PipeName);
 				}
 
-				pipe = await ConnectToPipeAsync(remoteConnectionInfo.PipeName!, cancellationToken).ConfigureAwait(false);
+				pipe = await ConnectToPipeAsync(remoteConnectionInfo.PipeName!, serverAlreadyListening: true, cancellationToken).ConfigureAwait(false);
 			}
 			else if (remoteConnectionInfo.ClrActivation != null)
 			{
@@ -642,9 +642,10 @@ public class RemoteServiceBroker : IServiceBroker, IDisposable, System.IAsyncDis
 	/// <param name="args">Details regarding what changes have occurred.</param>
 	protected virtual void OnAvailabilityChanged(object? sender, BrokeredServicesChangedEventArgs args) => this.AvailabilityChanged?.Invoke(this, args);
 
-	private static async Task<IDuplexPipe> ConnectToPipeAsync(string pipeName, CancellationToken cancellationToken)
+	private static async Task<IDuplexPipe> ConnectToPipeAsync(string pipeName, bool serverAlreadyListening, CancellationToken cancellationToken)
 	{
-		return (await ServerFactory.ConnectAsync(pipeName, cancellationToken).ConfigureAwait(false))
+		ServerFactory.ClientOptions options = new() { ServerAlreadyListening = serverAlreadyListening };
+		return (await ServerFactory.ConnectAsync(pipeName, options, cancellationToken).ConfigureAwait(false))
 			.UsePipe(cancellationToken: CancellationToken.None);
 	}
 

--- a/src/Microsoft.ServiceHub.Framework/ServerFactory.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServerFactory.cs
@@ -87,18 +87,24 @@ public static class ServerFactory
 		PipeOptions pipeOptions = StandardPipeOptions;
 		var name = TrimWindowsPrefixForDotNet(pipeName);
 		var maxRetries = options.FailFast ? 0 : int.MaxValue;
+
+		// A server creates its pipe before it hands out the name, so when the caller obtained the name from the
+		// server a missing pipe means the server is gone rather than not started yet, and waiting for it to appear
+		// would hang for the life of the cancellation token. A few retries still cover the moment where a server
+		// that accepts multiple clients is replacing the instance that a previous client just connected to.
+		int maxRetriesWhenPipeIsMissing = options.ServerAlreadyListening ? MaxRetryAttemptsForFileNotFoundException : int.MaxValue;
 		PipeStream? pipeStream = null;
 		try
 		{
 			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 			{
 				pipeStream = new AsyncNamedPipeClientStream(".", name, PipeDirection.InOut, pipeOptions);
-				await ((AsyncNamedPipeClientStream)pipeStream).ConnectAsync(maxRetries, ConnectRetryIntervalMs, cancellationToken).ConfigureAwait(false);
+				await ((AsyncNamedPipeClientStream)pipeStream).ConnectAsync(maxRetries, maxRetriesWhenPipeIsMissing, ConnectRetryIntervalMs, cancellationToken).ConfigureAwait(false);
 			}
 			else
 			{
 				pipeStream = new NamedPipeClientStream(".", name, PipeDirection.InOut, pipeOptions);
-				await ConnectWithRetryAsync((NamedPipeClientStream)pipeStream, fullPipeOptions, cancellationToken, maxRetries, withSpinningWait: options.CpuSpinOverFirstChanceExceptions).ConfigureAwait(false);
+				await ConnectWithRetryAsync((NamedPipeClientStream)pipeStream, fullPipeOptions, cancellationToken, name, maxRetriesWhenPipeIsMissing, maxRetries, withSpinningWait: options.CpuSpinOverFirstChanceExceptions).ConfigureAwait(false);
 			}
 
 			return pipeStream;
@@ -145,16 +151,19 @@ public static class ServerFactory
 	/// <param name="npcs">The named pipe client stream to connect.</param>
 	/// <param name="pipeOptions">The pipe options applied to this connection.</param>
 	/// <param name="cancellationToken">A cancellation token.</param>
+	/// <param name="pipePath">The path of the file that backs the pipe. Non-Windows pipe names are rooted paths, so this is the pipe name itself.</param>
+	/// <param name="maxRetriesWhenPipeIsMissing">The maximum number of retries to attempt while <paramref name="pipePath"/> does not exist, or <see cref="int.MaxValue"/> to not check.</param>
 	/// <param name="maxRetries">The maximum number of retries to attempt.</param>
 	/// <param name="withSpinningWait">Whether or not the connect should be attempted with a spinning wait.
 	/// If the pipe being connected to is known to exist, it is safe to use a spinning wait to avoid potentially throwing exceptions for retries.</param>
 	/// <returns>A <see cref="Task"/> that tracks the asynchronous connection attempt.</returns>
-	private static async Task ConnectWithRetryAsync(NamedPipeClientStream npcs, PipeOptions pipeOptions, CancellationToken cancellationToken, int maxRetries = int.MaxValue, bool withSpinningWait = false)
+	private static async Task ConnectWithRetryAsync(NamedPipeClientStream npcs, PipeOptions pipeOptions, CancellationToken cancellationToken, string pipePath, int maxRetriesWhenPipeIsMissing, int maxRetries = int.MaxValue, bool withSpinningWait = false)
 	{
 		Requires.NotNull(npcs, nameof(npcs));
 
 		ConcurrentDictionary<string, int> retryExceptions = new ConcurrentDictionary<string, int>();
 		int fileNotFoundRetryCount = 0;
+		int pipeMissingRetryCount = 0;
 		int totalRetries = 0;
 
 		while (true)
@@ -188,7 +197,24 @@ public static class ServerFactory
 					cancellationToken.ThrowIfCancellationRequested();
 					throw;
 				}
-				else if (((ex is IOException && ex.HResult == HRESULT_FROM_WIN32(WIN32_ERROR.ERROR_SEM_TIMEOUT)) || ex is TimeoutException) && totalRetries < maxRetries)
+
+				if (maxRetriesWhenPipeIsMissing < int.MaxValue)
+				{
+					// A missing pipe surfaces here as TimeoutException rather than FileNotFoundException, which the
+					// chain below would retry forever, so the absence of the file is what identifies this case.
+					// Only consecutive misses indicate a server that is gone. A server that is recreating its pipe
+					// produces isolated misses, so observing the pipe again resets the count.
+					if (File.Exists(pipePath))
+					{
+						pipeMissingRetryCount = 0;
+					}
+					else if (pipeMissingRetryCount++ >= maxRetriesWhenPipeIsMissing)
+					{
+						throw new FileNotFoundException($"The pipe '{pipePath}' does not exist.", pipePath);
+					}
+				}
+
+				if (((ex is IOException && ex.HResult == HRESULT_FROM_WIN32(WIN32_ERROR.ERROR_SEM_TIMEOUT)) || ex is TimeoutException) && totalRetries < maxRetries)
 				{
 					// Ignore and retry.
 					totalRetries++;
@@ -301,5 +327,21 @@ public static class ServerFactory
 		/// This property is only meaningful when <see cref="FailFast"/> is <see langword="false"/>.
 		/// </remarks>
 		public bool CpuSpinOverFirstChanceExceptions { get; init; }
+
+		/// <summary>
+		/// Gets a value indicating whether the server is known to have already created the pipe.
+		/// </summary>
+		/// <remarks>
+		/// <para>
+		/// Set this when the pipe name came from the server itself, which only publishes the name after it begins
+		/// listening. Under that condition a missing pipe proves the server is gone, so the connection fails with
+		/// <see cref="FileNotFoundException"/> instead of waiting for a pipe that will never be created.
+		/// A pipe that exists but has no free instance is still retried.
+		/// </para>
+		/// <para>
+		/// This property is only meaningful when <see cref="FailFast"/> is <see langword="false"/>.
+		/// </para>
+		/// </remarks>
+		public bool ServerAlreadyListening { get; init; }
 	}
 }

--- a/test/Microsoft.ServiceHub.Framework.Tests/ServerFactoryTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/ServerFactoryTests.cs
@@ -279,6 +279,51 @@ public class ServerFactoryTests : TestBase
 		}
 	}
 
+	[Fact]
+	public async Task ServerAlreadyListening_FailsFastWhenPipeIsMissing()
+	{
+		string channelName = ServerFactory.PrependPipePrefix($"{nameof(this.ServerAlreadyListening_FailsFastWhenPipeIsMissing)}_{Guid.NewGuid():N}");
+
+		// No server ever creates this pipe. The client claims the server already published the name,
+		// so the connection must report the missing pipe instead of waiting for the token to be canceled.
+		await Assert.ThrowsAsync<FileNotFoundException>(() => ServerFactory.ConnectAsync(
+			channelName,
+			new ServerFactory.ClientOptions { ServerAlreadyListening = true },
+			this.TimeoutToken));
+	}
+
+	[Fact]
+	public async Task ServerAlreadyListening_ConnectsToExistingServer()
+	{
+		AsyncManualResetEvent callbackEntered = new();
+		IIpcServer server = ServerFactory.Create(
+			stream =>
+			{
+				callbackEntered.Set();
+				stream.Dispose();
+				return Task.CompletedTask;
+			},
+			new ServerFactory.ServerOptions
+			{
+				TraceSource = this.CreateTestTraceSource(nameof(this.ServerAlreadyListening_ConnectsToExistingServer)),
+			});
+
+		try
+		{
+			using Stream clientStream = await ServerFactory.ConnectAsync(
+				server.Name,
+				new ServerFactory.ClientOptions { ServerAlreadyListening = true },
+				this.TimeoutToken);
+			await callbackEntered.WaitAsync(this.TimeoutToken);
+		}
+		finally
+		{
+			await server.DisposeAsync();
+		}
+
+		await server.Completion.WithCancellation(this.TimeoutToken);
+	}
+
 	private static PipeOptions GetPipeOptions(Stream pipeStream)
 	{
 		FieldInfo? pipeOptionsField = pipeStream.GetType().GetField("pipeOptions", BindingFlags.NonPublic | BindingFlags.Instance);


### PR DESCRIPTION
Fixes the ServiceHub half of the Copilot brokered service hang tracked by [AB#3039162](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3039162).

## Symptom

`IServiceBroker.GetProxyAsync` for a ServiceHub-hosted brokered service never completes. Telemetry for `Microsoft.VisualStudio.Copilot.Service` in SSMS shows first-acquisition times of 49 to 106 seconds, and a tail that runs to 555 seconds with no successful acquisition beyond an hour. Nothing is logged while it waits, so the failure is invisible until the process shuts down and cancels the token.

## Why it hangs

`RemoteServiceBroker.GetProxyAsync` asks the remote broker for a channel, gets a pipe name back, and connects to it:

```
GetProxyAsync -> RequestServiceChannelAsync -> ConnectToPipeAsync(remoteConnectionInfo.PipeName)
              -> ServerFactory.ConnectAsync(pipeName, default(ClientOptions), cancellationToken)
```

`default(ClientOptions)` means `FailFast == false`, which sets `maxRetries = int.MaxValue`. Both clients then retry until the caller's token is canceled. In VS and SSMS that token is tied to shell shutdown, so if the service host process died between handing out the pipe name and the client connecting, the client spins every 50 ms until the shell exits, emitting nothing.

On Windows the loop in `AsyncNamedPipeClientStream.ConnectAsync` is:

```csharp
while (!cancellationToken.IsCancellationRequested)
{
    if (retries > maxRetries || this.TryConnect()) break;
    retries++;
    var errorCode = Marshal.GetLastWin32Error();
    errorCodeMap[errorCode] = ...;
    await Task.Delay(retryDelayMs, cancellationToken).ConfigureAwait(false);
}
```

At `maxRetries = int.MaxValue` the `retries > maxRetries` guard is unreachable, so the token is the only exit.

`ServerFactory.ConnectWithRetryAsync`, used everywhere else, caps `FileNotFoundException` at `MaxRetryAttemptsForFileNotFoundException` but that cap does not fire here: `NamedPipeClientStream.ConnectAsync` reports an absent pipe as `TimeoutException`, which lands in the branch above it and retries while `totalRetries < maxRetries`. So that client hangs on a missing pipe too, just by a different route.

## Why a missing pipe is proof, not "not yet"

The host creates and listens on the pipe *before* the client can learn its name. In DevCore, `ServiceManager.StartServiceAsync` generates a fresh `Guid.NewGuid("N")` pipe name, calls `ServerFactoryCore.Create(pipeName, ...)`, and only then returns the name, with the comment "Since the client can't connect until this method returns, there's no risk of a race condition". The controller obtains that name over RPC and passes it to the client in `HubController.RequestServiceChannelAsync`.

So for this caller the name is single-use and nobody recreates it. If the pipe is absent, the server is gone and retrying is provably futile.

That is not true of `ServerFactory.ConnectAsync` in general. `ClientOptions.FailFast` documents that `false` means "continuously retry or wait for the server to listen for and respond to connection requests until it is canceled", and `ClientCallsBeforeServerIsReady` covers exactly that: a client connects to a name it chose itself, and the server is created afterward. That contract has to stay.

## The change

`ClientOptions.ServerAlreadyListening` lets a caller state that it obtained the pipe name from the server, so the server had already begun listening. When set, the client stops after `MaxRetryAttemptsForFileNotFoundException` consecutive attempts that found the pipe absent and throws `FileNotFoundException` naming the pipe. Observing the pipe again resets the count, so only an uninterrupted run of misses is treated as proof the server is gone.

The two clients identify "absent" differently, because only one of them gets a usable signal:

- Windows branches on `ERROR_FILE_NOT_FOUND` and `ERROR_PATH_NOT_FOUND` from `CreateFile`.
- Non-Windows tests for the backing file. `NamedPipeClientStream` collapses "no such pipe" and "server slow to accept" into the same `TimeoutException`, so the exception carries no usable signal. The file path is the pipe name itself, since `PrependPipePrefix` roots non-Windows names under `Path.GetTempPath()` and .NET uses a rooted pipe name as the socket path verbatim.

The retries matter and are not just a grace period. `IpcServer.ListenForIncomingRequestsAsync` has a real window with zero listening instances: it hands the current pipe to `ClientConnectedAsync` and only then creates the replacement when `AllowMultipleClients` is set, and it disposes and recreates the pipe in its `IOException` recovery path. A blanket fail-fast would break multi-client servers, so the bound is a small retry count rather than zero.

`RemoteServiceBroker` opts in at the two service-activation sites where the pipe name came from `RequestServiceChannelAsync`. The public `ConnectToServerAsync(string pipeName, ...)` overload, where the caller supplies a name from anywhere, does not opt in and keeps waiting as before.

Behavior for everyone else is unchanged:

| `FailFast` | `ServerAlreadyListening` | Missing pipe |
| --- | --- | --- |
| `false` | `false` | Retries until canceled (unchanged) |
| `false` | `true` | `FileNotFoundException` after the bounded retries |
| `true` | either | `TimeoutException` on the first attempt (unchanged) |

## No timeout

There is no deadline anywhere in this change. Slow machines, machines that sleep for a day mid-session, and hosts that are merely slow to accept a connection are unaffected, because a pipe that exists but has no free instance still retries under `maxRetries`. The only case that now fails is the one that is already unrecoverable: the pipe does not exist and nobody will ever create it.

## Also fixed

`TryConnect` disposed the invalid handle before the caller read `Marshal.GetLastWin32Error()`, so the code recorded in `errorCodeMap`, and printed in the `TimeoutException` message, could be the error from disposal rather than from `CreateFile`. The error is now captured immediately after the P/Invoke. The fix needs a trustworthy error code to branch on, and it makes the existing diagnostic message correct.

## Testing

- `ServerAlreadyListening_FailsFastWhenPipeIsMissing` connects to a pipe no server ever creates and asserts `FileNotFoundException` rather than hanging until the test timeout. This test caught that the non-Windows client needed the same fix: the first revision of this PR only handled Windows, and the test hung on the Linux leg.
- `ServerAlreadyListening_ConnectsToExistingServer` asserts the flag does not disturb a normal connect.
- `ClientCallsBeforeServerIsReady` is unchanged and still passes, which is the guard on the `FailFast` and wait-forever contracts.
- Full suite green locally on net8.0 (431) and net472 (434).

*Cowritten with Copilot (Claude Opus 5)*


