### PR TITLE
Fix pnpm bootstrap from Azure Artifacts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,10 +43,10 @@ The NPM package built from this repo restores its public dependencies from the A
 Then use the checked-in install script from the repo root:
 
 ```ps1
-corepack pnpm --dir src/servicebroker-npm run auth-install
+pnpm --dir src/servicebroker-npm run auth-install
 ```
 
-The `corepack` prefix is useful when `pnpm` is not already installed globally, because it activates the version pinned by this repo's `packageManager` field. If you already have that pnpm version active, `pnpm --dir src/servicebroker-npm run auth-install` works too.
+The root `init.ps1` script installs the pnpm version pinned by this repo's `packageManager` field.
 
 #### NPM/pnpm Maintenance
 

--- a/init.ps1
+++ b/init.ps1
@@ -160,9 +160,9 @@ try {
                         throw "Failure while refreshing NPM feed credentials."
                     }
                 }
-
-                . ./Set-CorepackEnvironment.ps1
             }
+
+            . ./Set-CorepackEnvironment.ps1
             npm install --global $packageManager --registry $env:COREPACK_NPM_REGISTRY --userconfig .\.npmrc
             if ($lastexitcode -ne 0) {
                 throw "Failure while installing package manager."

--- a/init.ps1
+++ b/init.ps1
@@ -146,6 +146,7 @@ try {
         Write-Host "Installing NPM packages" -ForegroundColor $HeaderColor
         Set-Location 'src/servicebroker-npm'
         $packageManager = (Get-Content package.json -Raw | ConvertFrom-Json).packageManager
+        $packageManagerName, $packageManagerVersion = $packageManager -split '@', 2
         $corepackEnvironment = @{}
         foreach ($corepackEnvironmentVariable in 'COREPACK_NPM_REGISTRY', 'COREPACK_NPM_TOKEN', 'COREPACK_NPM_USERNAME', 'COREPACK_NPM_PASSWORD') {
             $corepackEnvironment[$corepackEnvironmentVariable] = [Environment]::GetEnvironmentVariable($corepackEnvironmentVariable, 'Process')
@@ -153,11 +154,18 @@ try {
 
         try {
             if ($env:GITHUB_ACTIONS -ne 'true') {
+                if (Get-Command artifacts-npm-credprovider -ErrorAction SilentlyContinue) {
+                    artifacts-npm-credprovider -f -c .\.npmrc
+                    if ($lastexitcode -ne 0) {
+                        throw "Failure while refreshing NPM feed credentials."
+                    }
+                }
+
                 . ./Set-CorepackEnvironment.ps1
             }
-            corepack prepare $packageManager --activate
+            npm install --global $packageManager --registry $env:COREPACK_NPM_REGISTRY --userconfig .\.npmrc
             if ($lastexitcode -ne 0) {
-                throw "Failure while preparing package manager."
+                throw "Failure while installing package manager."
             }
         }
         finally {
@@ -169,10 +177,20 @@ try {
                 }
             }
         }
+
+        $actualPackageManagerVersion = pnpm --version
+        if ($lastexitcode -ne 0) {
+            throw "Failure while verifying package manager."
+        }
+
+        if ($actualPackageManagerVersion.Trim() -ne $packageManagerVersion) {
+            throw "Expected $packageManagerName $packageManagerVersion but found $($actualPackageManagerVersion.Trim())."
+        }
+
         Remove-Item .pnp.* -Force -ErrorAction SilentlyContinue
         $npmRestoreAttempts = 2
         for ($attempt = 1; $attempt -le $npmRestoreAttempts; $attempt++) {
-            corepack pnpm run auth-install
+            pnpm install --frozen-lockfile
             if ($lastexitcode -eq 0) {
                 break
             }

--- a/src/servicebroker-npm/package.json
+++ b/src/servicebroker-npm/package.json
@@ -8,7 +8,7 @@
 	"scripts": {
 		"build": "tsc",
 		"clean": "node -e \"require('fs').rmSync('js', { recursive: true, force: true })\"",
-		"auth-install": "corepack pnpm install --frozen-lockfile",
+		"auth-install": "pnpm install --frozen-lockfile",
 		"watch": "tsc -w",
 		"test": "jest",
 		"lint": "eslint src test"


### PR DESCRIPTION
Use npm instead of Corepack to install the pinned pnpm version because Azure Artifacts does not implement Corepack's version metadata endpoint. Refresh local feed credentials first and verify the installed version.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

Copilot-Session: 08722254-f06e-44de-a09f-4e0334e384dc
