### PR TITLE
Fail fast when a named pipe's unix domain socket path is too long

### DIFF
--- a/src/Microsoft.ServiceHub.Framework/IpcServer.cs
+++ b/src/Microsoft.ServiceHub.Framework/IpcServer.cs
@@ -40,6 +40,10 @@ internal class IpcServer : IDisposable, IIpcServer
 		// And when we're running off Windows, we need to specify the path so that we can tell other platforms where the pipe is.
 		this.Name = options.Name;
 
+		// Validate the length here rather than where the pipe is actually created, since that happens in the listening task
+		// and would merely fault Completion long after this constructor appeared to succeed.
+		ServerFactory.ThrowIfSocketPathTooLong(this.Name);
+
 		this.TraceSource = options.TraceSource ?? new TraceSource("ServiceHub.Framework pipe server", SourceLevels.Off);
 		this.Options = options;
 		this.createAndConfigureService = createAndConfigureService;

--- a/src/Microsoft.ServiceHub.Framework/ServerFactory.cs
+++ b/src/Microsoft.ServiceHub.Framework/ServerFactory.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.IO.Pipes;
 using System.Runtime.InteropServices;
 using System.Security.Principal;
+using System.Text;
 using Windows.Win32.Foundation;
 using static Windows.Win32.PInvoke;
 
@@ -23,6 +24,35 @@ public static class ServerFactory
 
 	private const int ConnectRetryIntervalMs = 50;
 	private const int MaxRetryAttemptsForFileNotFoundException = 3;
+
+	/// <summary>
+	/// The maximum length (in UTF-8 bytes) of the path to a unix domain socket on most unix-like operating systems.
+	/// </summary>
+	/// <remarks>
+	/// Linux declares <c>sockaddr_un.sun_path</c> as a 108 byte buffer, which leaves 107 bytes for the path
+	/// once the required null terminator is accounted for.
+	/// </remarks>
+	private const int MaxUnixDomainSocketPathLength = 107;
+
+	/// <summary>
+	/// The maximum length (in UTF-8 bytes) of the path to a unix domain socket on macOS.
+	/// </summary>
+	/// <remarks>
+	/// The BSD-derived <c>sockaddr_un.sun_path</c> buffer that macOS uses is only 104 bytes,
+	/// which leaves 103 bytes for the path once the required null terminator is accounted for.
+	/// </remarks>
+	private const int MaxMacDomainSocketPathLength = 103;
+
+	/// <summary>
+	/// The prefix that .NET prepends to a <em>relative</em> pipe name when deriving the path of the
+	/// unix domain socket that backs the pipe.
+	/// </summary>
+	/// <remarks>
+	/// This value is fixed in .NET itself, since changing it would prevent processes running on different
+	/// versions of .NET from connecting to each other.
+	/// </remarks>
+	private const string DotNetPipeFilePrefix = "CoreFxPipe_";
+
 	private static readonly string PipePrefix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"\\.\pipe" : Path.GetTempPath();
 
 	/// <summary>
@@ -86,6 +116,7 @@ public static class ServerFactory
 		PipeOptions fullPipeOptions = StandardPipeOptions;
 		PipeOptions pipeOptions = StandardPipeOptions;
 		var name = TrimWindowsPrefixForDotNet(pipeName);
+		ThrowIfSocketPathTooLong(name);
 		var maxRetries = options.FailFast ? 0 : int.MaxValue;
 
 		// A server creates its pipe before it hands out the name, so when the caller obtained the name from the
@@ -138,6 +169,48 @@ public static class ServerFactory
 		return RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && fullyQualifiedPipeName.StartsWith(WindowsPipePrefix, StringComparison.OrdinalIgnoreCase)
 			? fullyQualifiedPipeName.Substring(WindowsPipePrefix.Length)
 			: fullyQualifiedPipeName;
+	}
+
+	/// <summary>
+	/// Throws an exception when the unix domain socket that will back a named pipe would have a path
+	/// that is too long for the operating system to bind or connect to.
+	/// </summary>
+	/// <param name="pipeName">The pipe name that will be handed to <see cref="NamedPipeServerStream"/> or <see cref="NamedPipeClientStream"/>.</param>
+	/// <exception cref="PathTooLongException">Thrown when the socket path exceeds the limit imposed by the operating system.</exception>
+	/// <remarks>
+	/// <para>
+	/// On unix-like operating systems .NET backs a named pipe with a unix domain socket, whose path must fit within the
+	/// fixed-size <c>sockaddr_un.sun_path</c> buffer. Because <see cref="PrependPipePrefix(string)"/> roots pipe names at
+	/// <see cref="Path.GetTempPath()"/>, which honors the <c>TMPDIR</c> environment variable and is itself long by default
+	/// on macOS, that limit can be exceeded without the caller doing anything unusual.
+	/// </para>
+	/// <para>
+	/// Without this check the failure surfaces deep inside the socket layer with nothing to indicate that the length of the
+	/// path was the cause, and on the server it faults <see cref="IIpcServer.Completion"/> rather than the call that created
+	/// the server, so it typically presents as a client that cannot connect to a server that appeared to start successfully.
+	/// </para>
+	/// </remarks>
+	internal static void ThrowIfSocketPathTooLong(string pipeName)
+	{
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		{
+			// Windows named pipes are not backed by unix domain sockets, so no comparable limit applies.
+			return;
+		}
+
+		// Mirror how .NET derives the socket path from the pipe name so that the exception describes the path that would actually fail.
+		string socketPath = Path.IsPathRooted(pipeName)
+			? pipeName
+			: Path.Combine(Path.GetTempPath(), DotNetPipeFilePrefix) + pipeName;
+
+		// Assume the more generous limit for platforms we don't specifically recognize, so that this check
+		// never rejects a path that the operating system would in fact have accepted.
+		int maxLength = RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? MaxMacDomainSocketPathLength : MaxUnixDomainSocketPathLength;
+		int actualLength = Encoding.UTF8.GetByteCount(socketPath);
+		if (actualLength > maxLength)
+		{
+			throw new PathTooLongException($"The path '{socketPath}' is {actualLength} UTF-8 bytes long, which exceeds the {maxLength} byte limit that this operating system imposes on the unix domain socket that backs a named pipe. Use a shorter pipe name, or set the TMPDIR environment variable to a shorter path.");
+		}
 	}
 
 	private static IpcServer CreateCore(Func<Stream, Task> onConnectedCallback, ServerOptions options)

--- a/test/Microsoft.ServiceHub.Framework.Tests/ServerFactoryTests.cs
+++ b/test/Microsoft.ServiceHub.Framework.Tests/ServerFactoryTests.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using System.Diagnostics;
+using System.Globalization;
 using System.IO.Pipes;
 using System.Reflection;
 using System.Runtime.InteropServices;
@@ -10,10 +11,21 @@ using Microsoft.VisualStudio.Threading;
 
 public class ServerFactoryTests : TestBase
 {
+	private const string WindowsHasNoSocketPathLimit = "Windows named pipes are not backed by unix domain sockets, so no path length limit applies.";
+
 	public ServerFactoryTests(ITestOutputHelper logger)
 		: base(logger)
 	{
 	}
+
+	/// <summary>
+	/// Gets the maximum length (in UTF-8 bytes) that this operating system allows for the path to a unix domain socket.
+	/// </summary>
+	/// <remarks>
+	/// Linux allows 107 bytes and macOS allows 103, in both cases one less than the size of the
+	/// <c>sockaddr_un.sun_path</c> buffer, which must also hold a null terminator.
+	/// </remarks>
+	private static int MaxSocketPathLength => RuntimeInformation.IsOSPlatform(OSPlatform.OSX) ? 103 : 107;
 
 	private static PipeOptions CurrentUserOnlyPipeOption
 	{
@@ -322,6 +334,97 @@ public class ServerFactoryTests : TestBase
 		}
 
 		await server.Completion.WithCancellation(this.TimeoutToken);
+	}
+
+	[Fact]
+	public void Create_ThrowsWhenSocketPathExceedsPlatformLimit()
+	{
+		Assert.SkipWhen(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), WindowsHasNoSocketPathLimit);
+
+		int limit = MaxSocketPathLength;
+		string pipeName = CreateSocketPathWithByteLength(limit + 1);
+
+		PathTooLongException ex = Assert.Throws<PathTooLongException>(
+			() => ServerFactory.Create(DisposeStreamAsync, new ServerFactory.ServerOptions { Name = pipeName }));
+		this.Logger.WriteLine(ex.Message);
+
+		Assert.Contains(pipeName, ex.Message);
+		Assert.Contains((limit + 1).ToString(CultureInfo.InvariantCulture), ex.Message);
+		Assert.Contains(limit.ToString(CultureInfo.InvariantCulture), ex.Message);
+	}
+
+	[Fact]
+	public async Task Create_AllowsSocketPathAtPlatformLimit()
+	{
+		Assert.SkipWhen(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), WindowsHasNoSocketPathLimit);
+
+		string pipeName = CreateSocketPathWithByteLength(MaxSocketPathLength);
+		this.Logger.WriteLine($"Creating a server at a path of {MaxSocketPathLength} bytes: {pipeName}");
+
+		IIpcServer server = ServerFactory.Create(DisposeStreamAsync, new ServerFactory.ServerOptions { Name = pipeName });
+		await server.DisposeAsync();
+	}
+
+	[Fact]
+	public void Create_CountsSocketPathLengthInBytesRatherThanCharacters()
+	{
+		Assert.SkipWhen(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), WindowsHasNoSocketPathLimit);
+
+		// 'é' occupies two bytes when encoded as UTF-8, so this path is within the limit when measured
+		// in characters but one byte beyond it when measured the way the operating system measures it.
+		string pipeName = CreateSocketPathWithByteLength(MaxSocketPathLength - 1) + "é";
+		Assert.True(pipeName.Length <= MaxSocketPathLength, "The test path should be within the limit when measured in characters.");
+
+		PathTooLongException ex = Assert.Throws<PathTooLongException>(
+			() => ServerFactory.Create(DisposeStreamAsync, new ServerFactory.ServerOptions { Name = pipeName }));
+		this.Logger.WriteLine(ex.Message);
+	}
+
+	[Fact]
+	public async Task Create_AllowsLongPipeNamesOnWindows()
+	{
+		Assert.SkipUnless(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), "This test verifies that the unix domain socket path limit is not applied to Windows named pipes.");
+
+		// Comfortably longer than any unix domain socket path limit, but still a valid Windows pipe name.
+		string pipeName = "servicehub-" + new string('a', 200);
+
+		IIpcServer server = ServerFactory.Create(DisposeStreamAsync, new ServerFactory.ServerOptions { Name = pipeName });
+		await server.DisposeAsync();
+	}
+
+	[Fact]
+	public async Task ConnectAsync_ThrowsWhenSocketPathExceedsPlatformLimit()
+	{
+		Assert.SkipWhen(RuntimeInformation.IsOSPlatform(OSPlatform.Windows), WindowsHasNoSocketPathLimit);
+
+		string pipeName = CreateSocketPathWithByteLength(MaxSocketPathLength + 1);
+
+		PathTooLongException ex = await Assert.ThrowsAsync<PathTooLongException>(
+			() => ServerFactory.ConnectAsync(pipeName, this.TimeoutToken));
+		this.Logger.WriteLine(ex.Message);
+
+		Assert.Contains(pipeName, ex.Message);
+	}
+
+	private static Task DisposeStreamAsync(Stream stream)
+	{
+		stream.Dispose();
+		return Task.CompletedTask;
+	}
+
+	/// <summary>
+	/// Creates an absolute unix domain socket path of an exact length in UTF-8 bytes.
+	/// </summary>
+	/// <param name="byteLength">The required length of the path, in UTF-8 bytes.</param>
+	/// <returns>A rooted path made up entirely of ASCII characters.</returns>
+	/// <remarks>
+	/// The path is rooted at <c>/tmp</c> rather than <see cref="Path.GetTempPath()"/> so that the test
+	/// controls the total length regardless of how long the temporary directory happens to be.
+	/// </remarks>
+	private static string CreateSocketPathWithByteLength(int byteLength)
+	{
+		const string Prefix = "/tmp/servicehub-";
+		return Prefix + new string('a', byteLength - Prefix.Length);
 	}
 
 	private static PipeOptions GetPipeOptions(Stream pipeStream)


### PR DESCRIPTION
## Why

On unix-like operating systems, .NET backs a named pipe with a **unix domain socket file**, and the path to that file must fit within the fixed-size `sockaddr_un.sun_path` buffer — 108 bytes on Linux and 104 bytes on macOS, which leaves **107** and **103** usable bytes once the required null terminator is accounted for.

`ServerFactory` roots pipe names at `Path.GetTempPath()` on non-Windows platforms, and `PrependPipePrefix` hands that root out to callers:

```csharp
private static readonly string PipePrefix = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? @"\\.\pipe" : Path.GetTempPath();

public static string PrependPipePrefix(string leafPipeName) => Path.Combine(PipePrefix, leafPipeName);
```

`Path.GetTempPath()` honours `TMPDIR`, and on macOS it defaults to a long generated per-user directory such as `/var/folders/xy/abc123.../T/`. So the limit can be exceeded without the caller doing anything unusual. It isn't only a problem for callers who pick their own long name either: when `ServerOptions.Name` is `null`, `IpcServer` derives the name from that same root, so a caller who never chooses a name inherits the unbounded prefix too.

The part that makes this expensive to diagnose is **where the failure surfaces**. `IpcServer` creates the pipe inside its listening task, so the exception the socket layer raises faults `IIpcServer.Completion` rather than the `ServerFactory.Create` call. `Create` happily returns a name for a pipe that was never created, and unless the caller observes `Completion` the first visible symptom is a *client* that cannot connect to a server that started without error.

Here is what that looks like today on Linux with a 108-byte name (one byte over), observed with a scratch test against `main`:

```
Requested path length: 108 bytes (limit 107).
ServerFactory.Create RETURNED SUCCESSFULLY (no exception).
Socket file exists on disk? False
server.Completion.IsFaulted = True
Completion faulted with System.ArgumentOutOfRangeException
Message: The path '/tmp/servicehub-aaaa…aaaa' is of an invalid length for use with domain
         sockets on this platform.  The length must be between 1 and 108 characters,
         inclusive. (Parameter 'path')
```

The runtime's own message is reasonable — it just never reaches anyone, and nothing at the `ServerFactory` layer hints that path length was the cause.

This hazard is well known in the .NET ecosystem. Both MSBuild ([`src/Shared/NamedPipeUtil.cs`](https://github.com/dotnet/msbuild/blob/main/src/Shared/NamedPipeUtil.cs)) and Roslyn ([`src/Compilers/Shared/NamedPipeUtil.cs`](https://github.com/dotnet/roslyn/blob/main/src/Compilers/Shared/NamedPipeUtil.cs)) deliberately root their unix pipes at `/tmp` instead of the temp directory, with comments explaining exactly this constraint. The runtime's [`PipeStream.Unix.cs`](https://github.com/dotnet/runtime/blob/main/src/libraries/System.IO.Pipes/src/System/IO/Pipes/PipeStream.Unix.cs) notes the same thing, describing rooted pipe names as a way to "work around the limited length available for the pipe name when concatenated with the temp path".

## What changed

Added `ServerFactory.ThrowIfSocketPathTooLong`, called from two places:

- the `IpcServer` constructor, so `ServerFactory.Create` fails synchronously instead of returning a server whose `Completion` is already doomed; and
- `ServerFactory.ConnectAsync`, so the client side gets the same diagnostic. Today an over-limit name surfaces there as an `ArgumentOutOfRangeException` thrown from `UnixDomainSocketEndPoint`'s constructor, deep inside the socket layer — or, when `FailFast` is `true`, as a `TimeoutException` wrapping it, which reads as "the server didn't answer" rather than "this path can never work".

The helper mirrors how .NET derives the socket path from a pipe name — a rooted name is used verbatim, a relative one is prefixed with `Path.Combine(Path.GetTempPath(), "CoreFxPipe_")` — so the exception describes the path that would actually have failed. It throws `PathTooLongException` naming the effective path, its length in UTF-8 bytes, and the platform limit:

```
The path '/tmp/servicehub-aaaa…aaaa' is 108 UTF-8 bytes long, which exceeds the 107 byte
limit that this operating system imposes on the unix domain socket that backs a named pipe.
Use a shorter pipe name, or set the TMPDIR environment variable to a shorter path.
```

A few deliberate details:

- **Length is measured in UTF-8 bytes, not characters**, because that is what the OS measures. A non-ASCII username or `TMPDIR` can push a path over the limit while its character count still looks fine.
- **Unrecognised platforms get the more generous Linux limit (107).** A false positive here would be a regression — rejecting a path the OS would have accepted — whereas a false negative merely preserves today's behaviour. `OSPlatform.FreeBSD` isn't available on the `netstandard2.0`/`net472` targets, so BSD variants fall into this bucket.
- **Windows is untouched.** The helper returns immediately on Windows, where `\\.\pipe` has no comparable limit. On `net472` that branch is unconditionally taken, so it is a no-op there.
- No reflection, no allocation beyond the path string itself in the success case; trimming- and NativeAOT-safe.

## What this intentionally does *not* do

It does **not** change where sockets are created, e.g. by falling back to a shorter root when the temp-derived path would overflow.

A client and a server derive the pipe path independently, and they may be running different versions of this library. Any fallback that isn't byte-for-byte identical on both sides would cause a mixed-version pair to silently derive different paths and fail to find each other — trading a loud failure for a quiet one.

The runtime treats its own equivalent decision the same way. `PipeStream.Unix.cs` keeps its `CoreFxPipe_` naming scheme even where it would prefer to change it, noting that it "can't change the naming scheme used as that breaks the ability for code running on an older runtime to connect to code running on the newer runtime."

So that seemed like the wrong trade to make on behalf of every consumer, and not my call to make as an outside contributor, so I scoped this to validation and diagnostics. Happy to follow up with a relocation if you'd prefer one and have a view on how to sequence it compatibly.

I also left the underlying structure alone: `IpcServer` still creates its first pipe in the listening task rather than the constructor, which is the general reason construction-time pipe failures land on `Completion`. Validating in the constructor addresses this particular case without that restructuring, but you may consider the broader change worthwhile.

## Compatibility notes

- **Behaviour only changes for paths that already could not work.** Anything within the limit is unaffected.
- **`ServerFactory.ConnectAsync` surfaces a different exception type** in the over-limit case: `PathTooLongException` instead of `ArgumentOutOfRangeException` (or, when `FailFast` is `true`, instead of the `TimeoutException` that currently wraps it). All three are failures today; only the type and message change. I chose `PathTooLongException` over `ArgumentOutOfRangeException` because in the derived-default case the caller supplied no argument at all — the environment is at fault — and it exists on every target including `netstandard2.0` and `net472`.
- `ServerFactory.Create` now throws for an over-limit name where it previously returned a server that could never accept a connection.
- **The client-side check cannot reject a path that a server successfully bound.** It runs in the connecting process and reproduces exactly the path — and applies exactly the limit — that `UnixDomainSocketEndPoint` would apply moments later in that same process, so it only rejects paths whose `connect()` was already guaranteed to fail. Where the two sides disagree about `TMPDIR`, they were already resolving different files and could never have connected; the check surfaces that sooner and explains it, rather than causing it.

## Testing

Five tests added to `ServerFactoryTests`, following the existing `Assert.SkipWhen`/`Assert.SkipUnless` platform-gating style in that file:

| Test | Covers |
| --- | --- |
| `Create_ThrowsWhenSocketPathExceedsPlatformLimit` | One byte over the limit throws, and the message names the path, the actual byte count, and the limit |
| `Create_AllowsSocketPathAtPlatformLimit` | Exactly at the limit still works — guards against an off-by-one that would reject valid paths |
| `Create_CountsSocketPathLengthInBytesRatherThanCharacters` | A path within the limit in characters but over it in UTF-8 bytes is rejected |
| `Create_AllowsLongPipeNamesOnWindows` | A 200+ character name still works on Windows |
| `ConnectAsync_ThrowsWhenSocketPathExceedsPlatformLimit` | The client path produces the same diagnostic |

Full `Microsoft.ServiceHub.Framework.Tests` project, clean build (0 warnings, 0 errors) on each:

| Platform | Result |
| --- | --- |
| Windows, `net8.0` | 430 passed, 6 skipped, 0 failed |
| Windows, `net472` | 433 passed, 6 skipped, 0 failed |
| Linux (Ubuntu 24.04), `net8.0` | 432 passed, 4 skipped, 0 failed |

Three additional checks:

- **The 107-byte Linux limit was verified empirically**, not just read from a header: binding an AF_UNIX socket at a 107-byte path succeeds and at 108 bytes fails with `ENAMETOOLONG`. The macOS value of 103 comes from the BSD-derived `sun_path[104]` declaration and matches the runtime's own platform check; I don't have a macOS machine to confirm it empirically.
- **Negative control.** Reverting only the two product-code files while keeping the new tests makes three of them fail on Linux — including `Create_ThrowsWhenSocketPathExceedsPlatformLimit` failing with "No exception was thrown", which is precisely the defect. So the tests do catch the bug rather than merely describing the new code.
- **A client/server round-trip at exactly the limit was confirmed on Linux.** A server created at a 107-byte path binds the socket on disk, and a client connects to it through `ConnectAsync` without the new check firing — evidence that the validation does not reject paths that actually work at the boundary.

## A note on the message

I put the exception message inline rather than in `Strings.resx`, following the neighbouring throws in this area — the `FileNotFoundException` and `TimeoutException` in `ServerFactory.ConnectAsync`, and the `Requires.Argument` message in the `IpcServer` constructor. Very happy to move it into resources if you'd rather it be localised — just say the word.
